### PR TITLE
Add dev tooling, configurable scaffold paths, and formatting

### DIFF
--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -1,19 +1,68 @@
 <?php
 
-use function Laravel\Prompts\{confirm, info};
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
 
 class StarterKitPostInstall
 {
-    public function handle($console)
+    public function handle($console): void
     {
         info('Thanks for installing Bedrock starter kit!');
+
+        $this->mergeComposerScripts();
 
         $this->starRepo();
     }
 
+    protected function mergeComposerScripts(): void
+    {
+        $path = getcwd().'/composer.json';
+
+        $composer = json_decode(file_get_contents($path), true);
+
+        $composer['scripts'] = array_merge($composer['scripts'] ?? [], $this->customScripts());
+
+        file_put_contents(
+            $path,
+            json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
+        );
+
+        info('Added Bedrock composer scripts.');
+    }
+
+    /**
+     * @return array<string, string|array<int, string>>
+     */
+    protected function customScripts(): array
+    {
+        return [
+            'dev' => [
+                'Composer\\Config::disableProcessTimeout',
+                'npx concurrently -c "#c4b5fd,#fb7185,#fdba74" "php artisan queue:listen --tries=1" "php artisan pail --timeout=0" "npm run dev" --names=queue,logs,vite',
+            ],
+            'pint' => 'pint',
+            'pint:ci' => 'pint --test --parallel',
+            'phpstan' => 'phpstan analyse --configuration=phpstan.neon --no-progress',
+            'phpstan:ci' => 'phpstan analyse --configuration=phpstan.neon --no-progress --no-interaction',
+            'format' => [
+                'npm run lint',
+                'npm run format',
+                '@pint',
+                '@phpstan',
+            ],
+            'format:ci' => [
+                '@pint:ci',
+                '@phpstan:ci',
+            ],
+            'test' => [
+                'pest --parallel',
+            ],
+        ];
+    }
+
     protected function starRepo(): void
     {
-        if (!confirm('Would you like to star the Bedrock repo?')) {
+        if (! confirm('Would you like to star the Bedrock repo?')) {
             return;
         }
 

--- a/export/.claude/settings.local.json
+++ b/export/.claude/settings.local.json
@@ -14,7 +14,9 @@
       "Bash(php artisan *)",
       "Bash(composer run *)",
       "Bash(curl -s -o /tmp/home.html -w \"HTTP %{http_code} %{size_download}b\\\\n\" https://bedrock-demo.test/)",
-      "Read(//tmp/**)"
+      "Read(//tmp/**)",
+      "Bash(php *)",
+      "Bash(composer test *)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/export/app/Console/Commands/ClearDemoContent.php
+++ b/export/app/Console/Commands/ClearDemoContent.php
@@ -2,16 +2,17 @@
 
 namespace App\Console\Commands;
 
+use Illuminate\Console\Command;
+use Statamic\Entries\Entry;
+use Statamic\Facades\Asset;
+use Statamic\Facades\Entry as EntryFacade;
+use Statamic\Facades\GlobalVariables;
 use Statamic\Facades\Nav;
 use Statamic\Facades\Site;
 use Statamic\Facades\Term;
-use Statamic\Entries\Entry;
-use Illuminate\Console\Command;
-use Statamic\Facades\GlobalVariables;
-use Statamic\Facades\Entry as EntryFacade;
 
-use function Laravel\Prompts\{confirm, info};
-use Statamic\Facades\Asset;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
 
 class ClearDemoContent extends Command
 {
@@ -27,13 +28,13 @@ class ClearDemoContent extends Command
 
     public function handle(): int
     {
-        if (!$this->option('force')) {
+        if (! $this->option('force')) {
             $confirmed = confirm(
                 label: 'This will delete all Bedrock demo content. Continue?',
                 default: false
             );
 
-            if (!$confirmed) {
+            if (! $confirmed) {
                 info('Aborted.');
 
                 return self::SUCCESS;
@@ -65,15 +66,15 @@ class ClearDemoContent extends Command
     private function findHomeEntry(): ?Entry
     {
         return EntryFacade::whereCollection('pages')
-            ->filter(fn($entry) => $entry->slug() === 'home')
+            ->filter(fn ($entry) => $entry->slug() === 'home')
             ->first();
     }
 
     private function deleteEntries(?string $homeId): void
     {
         EntryFacade::all()
-            ->reject(fn($entry) => $entry->id() === $homeId) // Keep the home page
-            ->each(fn($entry) => $entry->delete());
+            ->reject(fn ($entry) => $entry->id() === $homeId) // Keep the home page
+            ->each(fn ($entry) => $entry->delete());
 
         info('Deleted all entries except home page.');
     }
@@ -95,9 +96,9 @@ class ClearDemoContent extends Command
     private function clearAllNavigationTrees(): void
     {
         Nav::all()->each(
-            fn($nav) => Site::all()
+            fn ($nav) => Site::all()
                 ->map->handle()
-                ->each(fn($site) => $nav->in($site)->tree([])->save())
+                ->each(fn ($site) => $nav->in($site)->tree([])->save())
         );
 
         info('Cleared all navigation trees.');
@@ -105,7 +106,7 @@ class ClearDemoContent extends Command
 
     private function deleteAllCategoryTerms(): void
     {
-        Term::whereTaxonomy('categories')->each(fn($term) => $term->delete());
+        Term::whereTaxonomy('categories')->each(fn ($term) => $term->delete());
 
         info("Deleted 'categories' taxonomy terms.");
     }
@@ -116,10 +117,10 @@ class ClearDemoContent extends Command
     private function deleteSelectedGlobalVariables(array $handles): void
     {
         foreach ($handles as $handle) {
-            GlobalVariables::whereSet($handle)->each(fn($vars) => $vars->delete());
+            GlobalVariables::whereSet($handle)->each(fn ($vars) => $vars->delete());
         }
 
-        info('Deleted global variables for sets: ' . implode(', ', $handles));
+        info('Deleted global variables for sets: '.implode(', ', $handles));
     }
 
     /**
@@ -128,8 +129,8 @@ class ClearDemoContent extends Command
     private function deleteAssets(): void
     {
         Asset::whereContainer('assets')
-            ->reject(fn($asset) => $asset->folder() === 'logos')
-            ->each(fn($asset) => $asset->delete());
+            ->reject(fn ($asset) => $asset->folder() === 'logos')
+            ->each(fn ($asset) => $asset->delete());
 
         info('Deleted demo assets (preserved logos).');
     }

--- a/export/app/Console/Commands/Scaffold/Concerns/ManagesFieldsetFiles.php
+++ b/export/app/Console/Commands/Scaffold/Concerns/ManagesFieldsetFiles.php
@@ -2,6 +2,8 @@
 
 namespace App\Console\Commands\Scaffold\Concerns;
 
+use Statamic\Facades\YAML;
+
 trait ManagesFieldsetFiles
 {
     /**
@@ -9,10 +11,10 @@ trait ManagesFieldsetFiles
      *
      * Checks for existing files and throws unless overwriting is allowed via $force.
      *
-     * @param string $fieldset New/target fieldset handle (snake_case)
-     * @param string $view     New/target view name (kebab-case)
-     * @param bool   $force    Allow overwriting existing files
-     * @param string $viewDir  Subdirectory under resources/views (e.g. 'blocks' or 'sets')
+     * @param  string  $fieldset  New/target fieldset handle (snake_case)
+     * @param  string  $view  New/target view name (kebab-case)
+     * @param  bool  $force  Allow overwriting existing files
+     * @param  string  $viewDir  Subdirectory under resources/views (e.g. 'blocks' or 'sets')
      *
      * @throws \RuntimeException When a file exists and $force is false
      */
@@ -22,11 +24,11 @@ trait ManagesFieldsetFiles
         bool $force,
         string $viewDir
     ): void {
-        $fieldsetPath = base_path("resources/fieldsets/{$fieldset}.yaml");
-        $viewPath = base_path("resources/views/{$viewDir}/{$view}.antlers.html");
+        $fieldsetPath = $this->fieldsetPathFor($fieldset);
+        $viewPath = $this->viewPathFor($view, $viewDir);
 
         foreach ([$fieldsetPath, $viewPath] as $path) {
-            if ($this->files->exists($path) && !$force) {
+            if ($this->files->exists($path) && ! $force) {
                 throw new \RuntimeException("File exists: {$path} (use --force to overwrite)");
             }
         }
@@ -35,17 +37,17 @@ trait ManagesFieldsetFiles
     /**
      * Delete fieldset and view files for a given handle.
      *
-     * @param string $fieldset Fieldset handle (snake_case)
-     * @param bool   $force    Ignore missing files when deleting
-     * @param string $viewDir  Subdirectory under resources/views (e.g. 'blocks' or 'sets')
+     * @param  string  $fieldset  Fieldset handle (snake_case)
+     * @param  bool  $force  Ignore missing files when deleting
+     * @param  string  $viewDir  Subdirectory under resources/views (e.g. 'blocks' or 'sets')
      *
      * @throws \RuntimeException When files are missing and $force is false
      */
     protected function deleteFilesFor(string $fieldset, bool $force, string $viewDir): void
     {
-        $fieldsetPath = base_path("resources/fieldsets/{$fieldset}.yaml");
+        $fieldsetPath = $this->fieldsetPathFor($fieldset);
         $view = str_replace('_', '-', $fieldset);
-        $viewPath = base_path("resources/views/{$viewDir}/{$view}.antlers.html");
+        $viewPath = $this->viewPathFor($view, $viewDir);
 
         $missing = [];
 
@@ -61,7 +63,7 @@ trait ManagesFieldsetFiles
             $missing[] = $viewPath;
         }
 
-        if ($missing && !$force) {
+        if ($missing && ! $force) {
             $list = implode("\n - ", $missing);
             throw new \RuntimeException(
                 "Some files were not found to delete:\n - {$list}\n(Use --force to ignore.)"
@@ -74,11 +76,11 @@ trait ManagesFieldsetFiles
      *
      * Replaces destination files if they already exist.
      *
-     * @param string $currentHandle Current fieldset handle (snake_case)
-     * @param string $originalView  Current view name (kebab-case)
-     * @param string $newFieldset   New fieldset handle (snake_case)
-     * @param string $newView       New view name (kebab-case)
-     * @param string $viewDir       Subdirectory under resources/views (e.g. 'blocks' or 'sets')
+     * @param  string  $currentHandle  Current fieldset handle (snake_case)
+     * @param  string  $originalView  Current view name (kebab-case)
+     * @param  string  $newFieldset  New fieldset handle (snake_case)
+     * @param  string  $newView  New view name (kebab-case)
+     * @param  string  $viewDir  Subdirectory under resources/views (e.g. 'blocks' or 'sets')
      */
     protected function moveFilesFor(
         string $currentHandle,
@@ -88,8 +90,8 @@ trait ManagesFieldsetFiles
         string $viewDir
     ): void {
         // Rename fieldset file
-        $oldFieldsetPath = base_path("resources/fieldsets/{$currentHandle}.yaml");
-        $newFieldsetPath = base_path("resources/fieldsets/{$newFieldset}.yaml");
+        $oldFieldsetPath = $this->fieldsetPathFor($currentHandle);
+        $newFieldsetPath = $this->fieldsetPathFor($newFieldset);
 
         if ($this->files->exists($oldFieldsetPath)) {
             if ($this->files->exists($newFieldsetPath)) {
@@ -101,8 +103,8 @@ trait ManagesFieldsetFiles
         }
 
         // Rename view file
-        $oldViewPath = base_path("resources/views/{$viewDir}/{$originalView}.antlers.html");
-        $newViewPath = base_path("resources/views/{$viewDir}/{$newView}.antlers.html");
+        $oldViewPath = $this->viewPathFor($originalView, $viewDir);
+        $newViewPath = $this->viewPathFor($newView, $viewDir);
 
         if ($this->files->exists($oldViewPath)) {
             if ($this->files->exists($newViewPath)) {
@@ -119,13 +121,29 @@ trait ManagesFieldsetFiles
      */
     protected function updateFieldsetTitle(string $fieldsetHandle, string $newTitle): void
     {
-        $path = base_path("resources/fieldsets/{$fieldsetHandle}.yaml");
-        if (!$this->files->exists($path)) {
+        $path = $this->fieldsetPathFor($fieldsetHandle);
+        if (! $this->files->exists($path)) {
             return; // nothing to update
         }
 
-        $data = \Statamic\Facades\YAML::file($path)->parse() ?? [];
+        $data = YAML::file($path)->parse();
         $data['title'] = $newTitle;
-        $this->files->put($path, \Statamic\Facades\YAML::dump($data));
+        $this->files->put($path, YAML::dump($data));
+    }
+
+    protected function fieldsetPathFor(string $handle): string
+    {
+        return config('statamic.bedrock.scaffold.fieldsets_path')."/{$handle}.yaml";
+    }
+
+    protected function viewPathFor(string $view, string $viewDir): string
+    {
+        $base = match ($viewDir) {
+            'blocks' => config('statamic.bedrock.scaffold.blocks_views_path'),
+            'sets' => config('statamic.bedrock.scaffold.sets_views_path'),
+            default => throw new \InvalidArgumentException("Unknown view dir: {$viewDir}"),
+        };
+
+        return "{$base}/{$view}.antlers.html";
     }
 }

--- a/export/app/Console/Commands/Scaffold/Concerns/UpdatesEntryContent.php
+++ b/export/app/Console/Commands/Scaffold/Concerns/UpdatesEntryContent.php
@@ -11,8 +11,8 @@ trait UpdatesEntryContent
     /**
      * Rename usages of a block type in all entries using the `blocks` field.
      *
-     * @param string $oldHandle Existing block handle to replace
-     * @param string $newHandle New block handle to set
+     * @param  string  $oldHandle  Existing block handle to replace
+     * @param  string  $newHandle  New block handle to set
      * @return int Number of entries updated
      */
     protected function renameBlockUsagesInEntries(string $oldHandle, string $newHandle): int
@@ -34,6 +34,7 @@ trait UpdatesEntryContent
             if ($blocks->toJson() !== $updated->toJson()) {
                 $entry->set('blocks', $updated->all());
                 $entry->save();
+
                 return 1;
             }
 
@@ -44,7 +45,7 @@ trait UpdatesEntryContent
     /**
      * Delete usages of a block type from all entries using the `blocks` field.
      *
-     * @param string $fieldset Block handle to remove
+     * @param  string  $fieldset  Block handle to remove
      * @return int Number of entries updated
      */
     protected function deleteBlockUsagesFromEntries(string $fieldset): int
@@ -57,7 +58,7 @@ trait UpdatesEntryContent
 
             $filtered = $blocks
                 ->reject(
-                    static fn($item): bool => is_array($item) &&
+                    static fn ($item): bool => is_array($item) &&
                         Arr::get($item, 'type') === $fieldset
                 )
                 ->values();
@@ -66,6 +67,7 @@ trait UpdatesEntryContent
             if ($removed > 0) {
                 $entry->set('blocks', $filtered->all());
                 $entry->save();
+
                 return 1;
             }
 
@@ -76,8 +78,8 @@ trait UpdatesEntryContent
     /**
      * Rename usages of an Article set in all entries using the `article` field.
      *
-     * @param string $oldHandle Existing set handle to replace
-     * @param string $newHandle New set handle to set
+     * @param  string  $oldHandle  Existing set handle to replace
+     * @param  string  $newHandle  New set handle to set
      * @return int Number of entries updated
      */
     protected function renameSetUsagesInEntries(string $oldHandle, string $newHandle): int
@@ -89,7 +91,7 @@ trait UpdatesEntryContent
             }
 
             $updated = $article->map(function ($node) use ($oldHandle, $newHandle) {
-                if (!is_array($node) || Arr::get($node, 'type') !== 'set') {
+                if (! is_array($node) || Arr::get($node, 'type') !== 'set') {
                     return $node;
                 }
 
@@ -103,6 +105,7 @@ trait UpdatesEntryContent
             if ($article->toJson() !== $updated->toJson()) {
                 $entry->set('article', $updated->all());
                 $entry->save();
+
                 return 1;
             }
 
@@ -113,7 +116,7 @@ trait UpdatesEntryContent
     /**
      * Delete usages of an Article set from all entries using the `article` field.
      *
-     * @param string $fieldset Set handle to remove
+     * @param  string  $fieldset  Set handle to remove
      * @return int Number of entries updated
      */
     protected function deleteSetUsagesFromEntries(string $fieldset): int
@@ -126,7 +129,7 @@ trait UpdatesEntryContent
 
             $filtered = $article
                 ->reject(static function ($node) use ($fieldset): bool {
-                    if (!is_array($node) || Arr::get($node, 'type') !== 'set') {
+                    if (! is_array($node) || Arr::get($node, 'type') !== 'set') {
                         return false; // keep non-set nodes
                     }
 
@@ -138,6 +141,7 @@ trait UpdatesEntryContent
             if ($removed > 0) {
                 $entry->set('article', $filtered->all());
                 $entry->save();
+
                 return 1;
             }
 

--- a/export/app/Console/Commands/Scaffold/DeleteBlock.php
+++ b/export/app/Console/Commands/Scaffold/DeleteBlock.php
@@ -2,15 +2,18 @@
 
 namespace App\Console\Commands\Scaffold;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Statamic\Facades\Entry;
-use Illuminate\Console\Command;
-use App\Support\Yaml\BlocksYaml;
-use Illuminate\Filesystem\Filesystem;
 use App\Console\Commands\Scaffold\Concerns\ManagesFieldsetFiles;
 use App\Console\Commands\Scaffold\Concerns\UpdatesEntryContent;
-use function Laravel\Prompts\{select, confirm, info, warning};
+use App\Support\Yaml\BlocksYaml;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+use Statamic\Facades\Entry;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\warning;
 
 class DeleteBlock extends Command
 {
@@ -69,7 +72,7 @@ class DeleteBlock extends Command
         }
 
         if (
-            !confirm(
+            ! confirm(
                 label: "Delete '{$blockLabel}' from '{$groups[$group]}' group?",
                 hint: (bool) $this->option('keep-files')
                     ? 'Only remove from blocks.yaml (files will be kept).'
@@ -86,7 +89,7 @@ class DeleteBlock extends Command
         try {
             $this->blocks->removeSet($group, $fieldset);
 
-            if (!(bool) $this->option('keep-files')) {
+            if (! (bool) $this->option('keep-files')) {
                 $this->deleteFilesFor(
                     fieldset: $fieldset,
                     force: (bool) $this->option('force'),
@@ -121,7 +124,7 @@ class DeleteBlock extends Command
                 }
 
                 return $blocks->contains(
-                    static fn($item): bool => is_array($item) &&
+                    static fn ($item): bool => is_array($item) &&
                         Arr::get($item, 'type') === $fieldset
                 );
             })

--- a/export/app/Console/Commands/Scaffold/DeleteSet.php
+++ b/export/app/Console/Commands/Scaffold/DeleteSet.php
@@ -2,15 +2,17 @@
 
 namespace App\Console\Commands\Scaffold;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Statamic\Facades\Entry;
-use Illuminate\Console\Command;
-use App\Support\Yaml\ArticleYaml;
-use Illuminate\Filesystem\Filesystem;
 use App\Console\Commands\Scaffold\Concerns\ManagesFieldsetFiles;
 use App\Console\Commands\Scaffold\Concerns\UpdatesEntryContent;
-use function Laravel\Prompts\{select, confirm, info, warning};
+use App\Support\Yaml\ArticleYaml;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Statamic\Facades\Entry;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\warning;
 
 class DeleteSet extends Command
 {
@@ -36,6 +38,7 @@ class DeleteSet extends Command
         $groups = $this->article->groups();
         if (empty($groups)) {
             warning('No groups found in article.yaml.');
+
             return self::FAILURE;
         }
 
@@ -50,6 +53,7 @@ class DeleteSet extends Command
         $sets = $this->article->sets($group);
         if (empty($sets)) {
             info("The '{$groups[$group]}' group has no sets.");
+
             return self::SUCCESS;
         }
 
@@ -69,7 +73,7 @@ class DeleteSet extends Command
         }
 
         if (
-            !confirm(
+            ! confirm(
                 label: "Delete '{$setLabel}' from '{$groups[$group]}' group?",
                 hint: (bool) $this->option('keep-files')
                     ? 'Only remove from article.yaml (files will be kept).'
@@ -78,13 +82,14 @@ class DeleteSet extends Command
             )
         ) {
             info('Aborted.');
+
             return self::SUCCESS;
         }
 
         try {
             $this->article->removeSet($group, $fieldset);
 
-            if (!(bool) $this->option('keep-files')) {
+            if (! (bool) $this->option('keep-files')) {
                 $this->deleteFilesFor(
                     fieldset: $fieldset,
                     force: (bool) $this->option('force'),
@@ -100,10 +105,12 @@ class DeleteSet extends Command
             }
         } catch (\Throwable $e) {
             $this->error($e->getMessage());
+
             return self::FAILURE;
         }
 
         info("Removed '{$setLabel}' set.");
+
         return self::SUCCESS;
     }
 
@@ -117,7 +124,7 @@ class DeleteSet extends Command
                 }
 
                 return $article->contains(static function ($node) use ($fieldset): bool {
-                    if (!is_array($node) || ($node['type'] ?? null) !== 'set') {
+                    if (! is_array($node) || ($node['type'] ?? null) !== 'set') {
                         return false;
                     }
 

--- a/export/app/Console/Commands/Scaffold/MakeBlock.php
+++ b/export/app/Console/Commands/Scaffold/MakeBlock.php
@@ -2,13 +2,17 @@
 
 namespace App\Console\Commands\Scaffold;
 
+use App\Console\Commands\Scaffold\Concerns\ManagesFieldsetFiles;
+use App\Support\Yaml\BlocksYaml;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Statamic\Facades\Config;
-use App\Support\Yaml\BlocksYaml;
-use App\Console\Commands\Scaffold\Concerns\ManagesFieldsetFiles;
-use function Laravel\Prompts\{select, suggest, text, info};
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\text;
 
 class MakeBlock extends Command
 {
@@ -66,10 +70,12 @@ class MakeBlock extends Command
             $this->updateBlocksFieldset($group, $fieldset, $name, $instructions);
         } catch (\Throwable $e) {
             $this->error($e->getMessage());
+
             return self::FAILURE;
         }
 
         info("Created '{$name}' block in '{$groups[$group]}' group.");
+
         return self::SUCCESS;
     }
 
@@ -79,7 +85,7 @@ class MakeBlock extends Command
             app_path('Console/Commands/Scaffold/stubs/fieldset_block.yaml.stub')
         );
         $this->files->put(
-            base_path("resources/fieldsets/{$fieldset}.yaml"),
+            $this->fieldsetPathFor($fieldset),
             Str::of($stub)->replace('{{ name }}', $name)
         );
     }
@@ -88,7 +94,7 @@ class MakeBlock extends Command
     {
         $stub = $this->files->get(app_path('Console/Commands/Scaffold/stubs/block.antlers.html.stub'));
         $this->files->put(
-            base_path("resources/views/blocks/{$view}.antlers.html"),
+            $this->viewPathFor($view, 'blocks'),
             Str::of($stub)->replace('{{ name }}', $name)
         );
     }

--- a/export/app/Console/Commands/Scaffold/MakeSet.php
+++ b/export/app/Console/Commands/Scaffold/MakeSet.php
@@ -2,13 +2,16 @@
 
 namespace App\Console\Commands\Scaffold;
 
+use App\Console\Commands\Scaffold\Concerns\ManagesFieldsetFiles;
+use App\Support\Yaml\ArticleYaml;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Statamic\Facades\Config;
-use Illuminate\Console\Command;
-use App\Support\Yaml\ArticleYaml;
-use Illuminate\Filesystem\Filesystem;
-use App\Console\Commands\Scaffold\Concerns\ManagesFieldsetFiles;
-use function Laravel\Prompts\{select, text, info};
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
 
 class MakeSet extends Command
 {
@@ -66,10 +69,12 @@ class MakeSet extends Command
             $this->updateArticleFieldset($group, $fieldset, $name, $instructions);
         } catch (\Throwable $e) {
             $this->error($e->getMessage());
+
             return self::FAILURE;
         }
 
         info("Created '{$name}' set in '{$groups[$group]}' group.");
+
         return self::SUCCESS;
     }
 
@@ -79,7 +84,7 @@ class MakeSet extends Command
             app_path('Console/Commands/Scaffold/stubs/fieldset_set.yaml.stub')
         );
         $this->files->put(
-            base_path("resources/fieldsets/{$fieldset}.yaml"),
+            $this->fieldsetPathFor($fieldset),
             Str::of($stub)->replace('{{ name }}', $name)
         );
     }
@@ -88,7 +93,7 @@ class MakeSet extends Command
     {
         $stub = $this->files->get(app_path('Console/Commands/Scaffold/stubs/set.antlers.html.stub'));
         $this->files->put(
-            base_path("resources/views/sets/{$view}.antlers.html"),
+            $this->viewPathFor($view, 'sets'),
             Str::of($stub)->replace('{{ name }}', $name)
         );
     }

--- a/export/app/Console/Commands/Scaffold/RenameBlock.php
+++ b/export/app/Console/Commands/Scaffold/RenameBlock.php
@@ -2,14 +2,18 @@
 
 namespace App\Console\Commands\Scaffold;
 
+use App\Console\Commands\Scaffold\Concerns\ManagesFieldsetFiles;
+use App\Console\Commands\Scaffold\Concerns\UpdatesEntryContent;
 use App\Support\Yaml\BlocksYaml;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Statamic\Facades\Config;
-use App\Console\Commands\Scaffold\Concerns\UpdatesEntryContent;
-use App\Console\Commands\Scaffold\Concerns\ManagesFieldsetFiles;
-use function Laravel\Prompts\{confirm, info, select, text};
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
 
 class RenameBlock extends Command
 {
@@ -36,6 +40,7 @@ class RenameBlock extends Command
         $groups = $this->blocks->groups();
         if (empty($groups)) {
             $this->error('No groups found in blocks.yaml.');
+
             return self::FAILURE;
         }
 
@@ -47,6 +52,7 @@ class RenameBlock extends Command
         $sets = $this->blocks->sets($currentGroup);
         if (empty($sets)) {
             info("The '{$groups[$currentGroup]}' group has no blocks.");
+
             return self::SUCCESS;
         }
 
@@ -71,7 +77,7 @@ class RenameBlock extends Command
         // 3) Optionally choose a new group to move to (skip prompt if args provided)
         $targetGroup = $currentGroup;
         $hasArgs = $this->argument('group') && $this->argument('current_name');
-        if (!$hasArgs && confirm('Move this block to a different group?', default: false)) {
+        if (! $hasArgs && confirm('Move this block to a different group?', default: false)) {
             $targetGroup = select(label: 'Select the new group', options: $groups, required: true);
         }
 
@@ -87,8 +93,8 @@ class RenameBlock extends Command
             $currentName = $this->blocks->sets($currentGroup)[$currentHandle] ?? null;
 
             if (
-                !$this->option('force') &&
-                !confirm(
+                ! $this->option('force') &&
+                ! confirm(
                     "Rename block '{$currentName}' to '{$newName}'? This will update all content entries."
                 )
             ) {

--- a/export/app/Console/Commands/Scaffold/RenameSet.php
+++ b/export/app/Console/Commands/Scaffold/RenameSet.php
@@ -9,7 +9,11 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Statamic\Facades\Config;
-use function Laravel\Prompts\{confirm, info, select, text};
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
 
 class RenameSet extends Command
 {
@@ -36,6 +40,7 @@ class RenameSet extends Command
         $groups = $this->article->groups();
         if (empty($groups)) {
             $this->error('No groups found in article.yaml.');
+
             return self::FAILURE;
         }
 
@@ -47,6 +52,7 @@ class RenameSet extends Command
         $sets = $this->article->sets($currentGroup);
         if (empty($sets)) {
             info("The '{$groups[$currentGroup]}' group has no sets.");
+
             return self::SUCCESS;
         }
 
@@ -71,7 +77,7 @@ class RenameSet extends Command
         // 3) Optionally choose a new group to move to (skip prompt if args provided)
         $targetGroup = $currentGroup;
         $hasArgs = $this->argument('group') && $this->argument('current_name');
-        if (!$hasArgs && confirm('Move this set to a different group?', default: false)) {
+        if (! $hasArgs && confirm('Move this set to a different group?', default: false)) {
             $targetGroup = select(label: 'Select the new group', options: $groups, required: true);
         }
 
@@ -87,12 +93,13 @@ class RenameSet extends Command
             $currentName = $this->article->sets($currentGroup)[$currentHandle] ?? null;
 
             if (
-                !$this->option('force') &&
-                !confirm(
+                ! $this->option('force') &&
+                ! confirm(
                     "Rename set '{$currentName}' to '{$newName}'? This will update all content entries."
                 )
             ) {
                 $this->info('Rename cancelled.');
+
                 return self::SUCCESS;
             }
 
@@ -115,10 +122,12 @@ class RenameSet extends Command
             }
         } catch (\Throwable $e) {
             $this->error($e->getMessage());
+
             return self::FAILURE;
         }
 
         info("Successfully renamed set '{$currentName}' to '{$newName}'");
+
         return self::SUCCESS;
     }
 

--- a/export/app/Http/Controllers/NewsletterController.php
+++ b/export/app/Http/Controllers/NewsletterController.php
@@ -3,20 +3,13 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\NewsletterRequest;
+use Illuminate\Http\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class NewsletterController extends Controller
 {
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function __invoke(NewsletterRequest $request)
+    public function __invoke(NewsletterRequest $request): JsonResponse
     {
-        // Your newsletter logic here
-
         return response()->json(
             [
                 'success' => true,

--- a/export/app/Http/Requests/NewsletterRequest.php
+++ b/export/app/Http/Requests/NewsletterRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class NewsletterRequest extends FormRequest
@@ -17,7 +18,7 @@ class NewsletterRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/export/app/Providers/AppServiceProvider.php
+++ b/export/app/Providers/AppServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace App\Providers;
 
-use Statamic\Statamic;
-use Statamic\Facades\Icon;
 use Illuminate\Support\ServiceProvider;
+use Statamic\Facades\Icon;
+use Statamic\Statamic;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/export/app/Support/Yaml/ArticleYaml.php
+++ b/export/app/Support/Yaml/ArticleYaml.php
@@ -8,6 +8,10 @@ class ArticleYaml extends GroupedSetsYaml
 {
     public function __construct(Filesystem $files)
     {
-        parent::__construct($files, 'resources/fieldsets/article.yaml', 'article');
+        parent::__construct(
+            $files,
+            config('statamic.bedrock.scaffold.fieldsets_path').'/article.yaml',
+            'article'
+        );
     }
 }

--- a/export/app/Support/Yaml/BlocksYaml.php
+++ b/export/app/Support/Yaml/BlocksYaml.php
@@ -8,6 +8,10 @@ class BlocksYaml extends GroupedSetsYaml
 {
     public function __construct(Filesystem $files)
     {
-        parent::__construct($files, 'resources/fieldsets/blocks.yaml', 'blocks');
+        parent::__construct(
+            $files,
+            config('statamic.bedrock.scaffold.fieldsets_path').'/blocks.yaml',
+            'blocks'
+        );
     }
 }

--- a/export/app/Support/Yaml/GroupedSetsYaml.php
+++ b/export/app/Support/Yaml/GroupedSetsYaml.php
@@ -28,7 +28,7 @@ class GroupedSetsYaml
         $data = $this->read();
         $root = $this->groupsRoot($data);
 
-        if (!array_key_exists($groupHandle, $root)) {
+        if (! array_key_exists($groupHandle, $root)) {
             throw new \RuntimeException("Group '{$groupHandle}' not found in {$this->path}.");
         }
 
@@ -40,13 +40,13 @@ class GroupedSetsYaml
         $data = $this->read();
         $root = $this->groupsRoot($data);
 
-        if (!isset($root[$groupHandle])) {
+        if (! isset($root[$groupHandle])) {
             throw new \RuntimeException("Group '{$groupHandle}' not found.");
         }
 
         $sets = collect(Arr::get($root[$groupHandle], 'sets', []))
             ->put($setHandle, $set)
-            ->pipe(fn($collection) => $this->sortKeysNaturally($collection->all()));
+            ->pipe(fn ($collection) => $this->sortKeysNaturally($collection->all()));
 
         $data = $this->updateGroupSets($data, $groupHandle, $sets);
 
@@ -58,13 +58,13 @@ class GroupedSetsYaml
         $data = $this->read();
         $root = $this->groupsRoot($data);
 
-        if (!isset($root[$groupHandle]['sets'][$setHandle])) {
+        if (! isset($root[$groupHandle]['sets'][$setHandle])) {
             throw new \RuntimeException("Set '{$setHandle}' not found in group '{$groupHandle}'.");
         }
 
         $sets = collect($root[$groupHandle]['sets'] ?? [])
             ->except($setHandle)
-            ->pipe(fn($collection) => $this->sortKeysNaturally($collection->all()));
+            ->pipe(fn ($collection) => $this->sortKeysNaturally($collection->all()));
 
         $data = $this->updateGroupSets($data, $groupHandle, $sets);
 
@@ -100,7 +100,7 @@ class GroupedSetsYaml
 
     private function groupFieldIndexOrFail(array $data): int
     {
-        if (!isset($data['fields']) || !is_array($data['fields'])) {
+        if (! isset($data['fields']) || ! is_array($data['fields'])) {
             throw new \RuntimeException(
                 "Invalid YAML structure in {$this->path}: missing 'fields'."
             );
@@ -120,7 +120,7 @@ class GroupedSetsYaml
     private function sortKeysNaturally(array $items): array
     {
         return collect($items)
-            ->sortKeysUsing(static fn(string $a, string $b): int => strnatcasecmp($a, $b))
+            ->sortKeysUsing(static fn (string $a, string $b): int => strnatcasecmp($a, $b))
             ->all();
     }
 
@@ -128,7 +128,7 @@ class GroupedSetsYaml
     {
         return collect($items)
             ->mapWithKeys(
-                fn(array $config, string $handle) => [
+                fn (array $config, string $handle) => [
                     $handle => (string) ($config['display'] ?? Stringy::humanize($handle)),
                 ]
             )
@@ -137,16 +137,15 @@ class GroupedSetsYaml
 
     private function read(): array
     {
-        $full = base_path($this->path);
-        if (!$this->files->exists($full)) {
+        if (! $this->files->exists($this->path)) {
             throw new \RuntimeException("Missing fieldset file: {$this->path}");
         }
 
-        return YAML::file($full)->parse() ?? [];
+        return YAML::file($this->path)->parse();
     }
 
     private function write(array $data): void
     {
-        $this->files->put(base_path($this->path), YAML::dump($data));
+        $this->files->put($this->path, YAML::dump($data));
     }
 }

--- a/export/app/Tags/YoutubeId.php
+++ b/export/app/Tags/YoutubeId.php
@@ -8,10 +8,8 @@ class YoutubeId extends Tags
 {
     /**
      * The {{ youtube_id }} tag.
-     *
-     * @return string|array
      */
-    public function index()
+    public function index(): string|array|false
     {
         /**
          * https://gist.github.com/leogopal/b429f9700d473a55f70819dc6e5195f0

--- a/export/config/statamic/bedrock.php
+++ b/export/config/statamic/bedrock.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'scaffold' => [
+        'fieldsets_path' => resource_path('fieldsets'),
+        'blocks_views_path' => resource_path('views/blocks'),
+        'sets_views_path' => resource_path('views/sets'),
+    ],
+];

--- a/export/config/statamic/git.php
+++ b/export/config/statamic/git.php
@@ -133,8 +133,8 @@ return [
     */
 
     'commands' => [
-        config('statamic.git.binary') . ' add {{ paths }}',
-        config('statamic.git.binary') .
+        config('statamic.git.binary').' add {{ paths }}',
+        config('statamic.git.binary').
         ' -c "user.name={{ name }}" -c "user.email={{ email }}" commit -m "{{ message }} [BOT]"',
     ],
 

--- a/export/phpstan.neon
+++ b/export/phpstan.neon
@@ -1,0 +1,31 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+    - vendor/nesbot/carbon/extension.neon
+
+parameters:
+    level: 5
+
+    paths:
+        - app
+        - config
+        - bootstrap
+        - database/factories
+        - routes
+
+    ignoreErrors:
+        -
+            identifier: method.notFound
+            reportUnmatched: false
+            message: '#Statamic\\Contracts\\#'
+        -
+            identifier: staticMethod.notFound
+            reportUnmatched: false
+            message: '#Statamic\\Contracts\\#'
+        -
+            identifier: property.notFound
+            reportUnmatched: false
+            message: '#Statamic\\(Contracts\\)?Entries\\Entry#'
+        -
+            identifier: property.protected
+            reportUnmatched: false
+            message: '#Statamic\\Entries\\Entry#'

--- a/export/resources/views/blocks/blog-excerpt.antlers.html
+++ b/export/resources/views/blocks/blog-excerpt.antlers.html
@@ -1,7 +1,6 @@
 <section id="{{ type | slugify }}" class="m-section">
     <div class="container">
         <s:partial:components.section-header :title="title" :text="text" />
-
         {{ if query == 'custom' }}
             {{ blog_posts = entries }}
         {{ elseif query == 'latest' }}
@@ -9,7 +8,6 @@
         {{ elseif query == 'featured' }}
             {{ blog_posts = {collection:posts :limit="limit" featured="true" sort="order"} }}
         {{ /if }}
-
         <div class="site-grid mx-auto max-w-2xl gap-y-20 lg:max-w-none">
             {{ blog_posts }}
                 <s:partial:components.entry-posts

--- a/export/resources/views/blocks/blog-paginated.antlers.html
+++ b/export/resources/views/blocks/blog-paginated.antlers.html
@@ -18,7 +18,6 @@
                     {{ /posts }}
                 </div>
             {{ /if }}
-
             {{ if paginate }}
                 <s:partial:components.ui.pagination.pagination class="mt-20" :paginate="paginate" />
             {{ /if }}

--- a/export/resources/views/blocks/faqs.antlers.html
+++ b/export/resources/views/blocks/faqs.antlers.html
@@ -2,7 +2,10 @@
     <div class="container max-w-4xl">
         <s:partial:components.section-header :title="title" :text="text" />
 
-        <s:partial:components.faqs :items="items" class="divide-y divide-gray-300 border-b border-gray-300">
+        <s:partial:components.faqs
+            :items="items"
+            class="divide-y divide-gray-300 border-b border-gray-300"
+        >
             {{ items }}
                 <s:partial:components.faqs-item :title="title" :text="text" />
             {{ /items }}

--- a/export/resources/views/blocks/hero-demo.antlers.html
+++ b/export/resources/views/blocks/hero-demo.antlers.html
@@ -2,14 +2,50 @@
     {{ push:scripts }}
         <script src="/vendor/statamic/frontend/js/helpers.js" defer></script>
         <script>
-            window.heroDemoContact = () => ({ form: { name: '', email: '', message: '', validate() { return true }, invalid() { return false } } });
-            window.heroDemoNewsletter = () => ({ form: { email: '', frequency: 'weekly', topics: [], marketing: false, validate() { return true }, invalid() { return false } } });
-            window.heroDemoPreferences = () => ({ form: { theme: 'system', language: 'en', notifications: false, validate() { return true }, invalid() { return false } } });
-            window.heroDemoSteps = () => ({ form: { steps: 5000 } });
+            window.heroDemoContact = () => ({
+                form: {
+                    name: '',
+                    email: '',
+                    message: '',
+                    validate() {
+                        return true
+                    },
+                    invalid() {
+                        return false
+                    },
+                },
+            })
+            window.heroDemoNewsletter = () => ({
+                form: {
+                    email: '',
+                    frequency: 'weekly',
+                    topics: [],
+                    marketing: false,
+                    validate() {
+                        return true
+                    },
+                    invalid() {
+                        return false
+                    },
+                },
+            })
+            window.heroDemoPreferences = () => ({
+                form: {
+                    theme: 'system',
+                    language: 'en',
+                    notifications: false,
+                    validate() {
+                        return true
+                    },
+                    invalid() {
+                        return false
+                    },
+                },
+            })
+            window.heroDemoSteps = () => ({ form: { steps: 5000 } })
         </script>
     {{ /push:scripts }}
 {{ /once }}
-
 <section class="py-8 md:py-16 lg:py-20">
     <div class="container flex flex-col items-center gap-4 text-center xl:gap-6">
         <h1 class="h1 text-balance">{{ title }}</h1>
@@ -28,7 +64,9 @@
                     <div class="card shadow-none">
                         <div class="card__header">
                             <p class="leading-none font-semibold">Contact us</p>
-                            <p class="text-muted-foreground text-sm">Get in touch and we'll respond within 24 hours.</p>
+                            <p class="text-muted-foreground text-sm">
+                                Get in touch and we'll respond within 24 hours.
+                            </p>
                         </div>
                         <div class="flex flex-1 flex-col gap-4">
                             <div class="grid gap-3">
@@ -51,7 +89,10 @@
                                 />
                             </div>
                             <div class="grid gap-3">
-                                <s:partial:components.ui.label id="contact_message" display="Message" />
+                                <s:partial:components.ui.label
+                                    id="contact_message"
+                                    display="Message"
+                                />
                                 <s:partial:components.ui.form.textarea
                                     model="form.message"
                                     handle="contact_message"
@@ -61,22 +102,32 @@
                                 />
                             </div>
                             <div class="flex justify-end">
-                                <s:partial:components.ui.button as="button" type="button">Submit</s:partial:components.ui.button>
+                                <s:partial:components.ui.button as="button" type="button">
+                                    Submit
+                                </s:partial:components.ui.button>
                             </div>
                         </div>
                     </div>
                 </div>
 
                 {{# Newsletter Form #}}
-                <div x-data="heroDemoNewsletter()" class="col-span-full md:col-span-6 lg:col-span-3">
+                <div
+                    x-data="heroDemoNewsletter()"
+                    class="col-span-full md:col-span-6 lg:col-span-3"
+                >
                     <div class="card shadow-none">
                         <div class="card__header">
                             <p class="leading-none font-semibold">Newsletter</p>
-                            <p class="text-muted-foreground text-sm">Stay updated with our latest insights and tips.</p>
+                            <p class="text-muted-foreground text-sm">
+                                Stay updated with our latest insights and tips.
+                            </p>
                         </div>
                         <div class="flex flex-1 flex-col gap-4">
                             <div class="grid gap-3">
-                                <s:partial:components.ui.label id="newsletter_email" display="Email Address" />
+                                <s:partial:components.ui.label
+                                    id="newsletter_email"
+                                    display="Email Address"
+                                />
                                 <s:partial:components.ui.form.text
                                     model="form.email"
                                     handle="email"
@@ -87,11 +138,7 @@
                             </div>
                             <div class="grid gap-3">
                                 <s:partial:components.ui.label id="frequency" display="Frequency" />
-                                {{ frequency_options = [
-                                    'daily' => 'Daily updates',
-                                    'weekly' => 'Weekly digest',
-                                    'monthly' => 'Monthly newsletter',
-                                ] }}
+                                {{ frequency_options = ['daily' => 'Daily updates', 'weekly' => 'Weekly digest', 'monthly' => 'Monthly newsletter', ] }}
                                 <s:partial:components.ui.form.select
                                     model="form.frequency"
                                     handle="frequency"
@@ -100,11 +147,7 @@
                                 />
                             </div>
                             <div class="grid gap-3">
-                                {{ topics_options = [
-                                    'design' => 'Design tips',
-                                    'development' => 'Development news',
-                                    'marketing' => 'Marketing insights',
-                                ] }}
+                                {{ topics_options = ['design' => 'Design tips', 'development' => 'Development news', 'marketing' => 'Marketing insights', ] }}
                                 <s:partial:components.ui.form.checkboxes
                                     model="form.topics"
                                     handle="topics"
@@ -114,7 +157,9 @@
                                 />
                             </div>
                             <div class="flex justify-end">
-                                <s:partial:components.ui.button as="button" type="button">Subscribe</s:partial:components.ui.button>
+                                <s:partial:components.ui.button as="button" type="button">
+                                    Subscribe
+                                </s:partial:components.ui.button>
                             </div>
                         </div>
                     </div>
@@ -127,29 +172,35 @@
                     <div class="card shadow-none">
                         <div class="card__header">
                             <p class="leading-none font-semibold">Featured posts</p>
-                            <p class="text-muted-foreground text-sm">Browse our most popular posts.</p>
+                            <p class="text-muted-foreground text-sm">
+                                Browse our most popular posts.
+                            </p>
                         </div>
 
                         <div class="flex flex-1 items-center px-8">
-                            {{ partial:components/ui/carousel/carousel
-                                class="w-full max-w-full"
-                                opts="loop: true, align: 'center'"
-                            }}
+                            {{ partial:components/ui/carousel/carousel class="w-full max-w-full" opts="loop: true, align: 'center'" }}
                                 {{ slot:content }}
                                     {{ loop times="5" }}
                                         <s:partial:components.ui.carousel.slide>
                                             <div class="p-1">
-                                                <div class="card aspect-square items-center justify-center lg:aspect-3/2 xl:aspect-square">
-                                                    <span class="text-4xl font-semibold">{{ count }}</span>
+                                                <div
+                                                    class="card aspect-square items-center justify-center lg:aspect-3/2 xl:aspect-square"
+                                                >
+                                                    <span class="text-4xl font-semibold">
+                                                        {{ count }}
+                                                    </span>
                                                 </div>
                                             </div>
                                         </s:partial:components.ui.carousel.slide>
                                     {{ /loop }}
                                 {{ /slot:content }}
-
                                 {{ slot:nav }}
-                                    <s:partial:components.ui.carousel.previous class="btn--outline btn--round" />
-                                    <s:partial:components.ui.carousel.next class="btn--outline btn--round" />
+                                    <s:partial:components.ui.carousel.previous
+                                        class="btn--outline btn--round"
+                                    />
+                                    <s:partial:components.ui.carousel.next
+                                        class="btn--outline btn--round"
+                                    />
                                 {{ /slot:nav }}
                             {{ /partial:components/ui/carousel/carousel }}
                         </div>
@@ -157,7 +208,10 @@
                 </div>
 
                 {{# Preferences Form #}}
-                <div x-data="heroDemoPreferences()" class="col-span-full md:col-span-6 lg:col-span-3">
+                <div
+                    x-data="heroDemoPreferences()"
+                    class="col-span-full md:col-span-6 lg:col-span-3"
+                >
                     <div class="card shadow-none">
                         <div class="card__header">
                             <p class="leading-none font-semibold">Preferences</p>
@@ -166,11 +220,7 @@
                         <div class="flex flex-1 flex-col gap-6">
                             <div class="grid gap-6">
                                 <div class="grid gap-3">
-                                    {{ theme_options = [
-                                        'light' => 'Light mode',
-                                        'dark' => 'Dark mode',
-                                        'system' => 'System default',
-                                    ] }}
+                                    {{ theme_options = ['light' => 'Light mode', 'dark' => 'Dark mode', 'system' => 'System default', ] }}
                                     <s:partial:components.ui.form.radio
                                         id="theme"
                                         handle="theme"
@@ -180,20 +230,11 @@
                                     />
                                 </div>
                                 <div class="grid gap-3">
-                                    <s:partial:components.ui.label id="language" display="Language" />
-                                    {{ languages = [
-                                        'en' => 'English',
-                                        'es' => 'Spanish',
-                                        'fr' => 'French',
-                                        'de' => 'German',
-                                        'it' => 'Italian',
-                                        'pt' => 'Portuguese',
-                                        'ru' => 'Russian',
-                                        'zh' => 'Chinese',
-                                        'ja' => 'Japanese',
-                                        'ko' => 'Korean',
-                                        'ar' => 'Arabic',
-                                    ] }}
+                                    <s:partial:components.ui.label
+                                        id="language"
+                                        display="Language"
+                                    />
+                                    {{ languages = ['en' => 'English', 'es' => 'Spanish', 'fr' => 'French', 'de' => 'German', 'it' => 'Italian', 'pt' => 'Portuguese', 'ru' => 'Russian', 'zh' => 'Chinese', 'ja' => 'Japanese', 'ko' => 'Korean', 'ar' => 'Arabic', ] }}
                                     <s:partial:components.ui.form.combobox
                                         id="language"
                                         handle="language"
@@ -211,7 +252,12 @@
                                     />
                                 </div>
                             </div>
-                            <s:partial:components.ui.button class="w-full" variant="outline" type="button" as="button">
+                            <s:partial:components.ui.button
+                                class="w-full"
+                                variant="outline"
+                                type="button"
+                                as="button"
+                            >
                                 Save preferences
                             </s:partial:components.ui.button>
                         </div>
@@ -232,24 +278,7 @@
         <div class="col-span-full grid grid-cols-1 gap-4 md:grid-cols-2 xl:col-span-6">
             {{# Tabs #}}
             <div class="grid gap-4 xl:col-span-full xl:grid-cols-2">
-                {{ services_tabs = [
-                    [
-                        'title' => 'AI agents',
-                        'description' => 'AI agents can help you with a wide range of tasks, from customer service to data analysis.',
-                        'features' => ['Automated workflows', 'Data analysis', 'Customer service'],
-                    ],
-                    [
-                        'title' => 'Web apps',
-                        'description' => 'Build apps for your business.',
-                        'features' => ['Filament dashboards', 'SPA apps with Inertia and Vue/React', 'Laravel apps'],
-                    ],
-                    [
-                        'title' => 'Websites',
-                        'description' => 'Build high-converting websites.',
-                        'features' => ['Beautiful design', 'Lightning-fast loading', 'SEO-friendly'],
-                    ],
-                ] }}
-
+                {{ services_tabs = [['title' => 'AI agents', 'description' => 'AI agents can help you with a wide range of tasks, from customer service to data analysis.', 'features' => ['Automated workflows', 'Data analysis', 'Customer service'], ], ['title' => 'Web apps', 'description' => 'Build apps for your business.', 'features' => ['Filament dashboards', 'SPA apps with Inertia and Vue/React', 'Laravel apps'], ], ['title' => 'Websites', 'description' => 'Build high-converting websites.', 'features' => ['Beautiful design', 'Lightning-fast loading', 'SEO-friendly'], ], ] }}
                 {{ partial:components/ui/tabs/tabs list_class="bg-muted text-muted-foreground flex min-h-9 w-full items-center justify-center rounded-lg p-[3px] outline-none" }}
                     {{ slot:list }}
                         {{ services_tabs }}
@@ -262,7 +291,6 @@
                             </s:partial:components.ui.tabs.trigger>
                         {{ /services_tabs }}
                     {{ /slot:list }}
-
                     {{ slot:panels }}
                         {{ services_tabs }}
                             <s:partial:components.ui.tabs.panel
@@ -278,7 +306,12 @@
                                     </ul>
                                 </div>
                                 <div class="card__footer">
-                                    <s:partial:components.ui.button variant="outline" size="sm" type="button" as="button">
+                                    <s:partial:components.ui.button
+                                        variant="outline"
+                                        size="sm"
+                                        type="button"
+                                        as="button"
+                                    >
                                         Learn more
                                     </s:partial:components.ui.button>
                                 </div>
@@ -286,12 +319,13 @@
                         {{ /services_tabs }}
                     {{ /slot:panels }}
                 {{ /partial:components/ui/tabs/tabs }}
-
                 <div x-data="heroDemoSteps()">
                     <div class="card shadow-none">
                         <div class="card__header">
                             <p class="leading-none font-semibold">Move goal</p>
-                            <p class="text-muted-foreground text-sm">Set your daily activity goal.</p>
+                            <p class="text-muted-foreground text-sm">
+                                Set your daily activity goal.
+                            </p>
                         </div>
                         <div class="flex flex-1 flex-col items-center gap-4">
                             <s:partial:components.ui.form.stepper
@@ -305,7 +339,10 @@
                                 :max="30000"
                                 class="flex flex-col px-4 text-4xl font-bold tracking-tighter"
                             >
-                                <label for="steps" class="text-muted-foreground text-xs font-normal tracking-normal uppercase">
+                                <label
+                                    for="steps"
+                                    class="text-muted-foreground text-xs font-normal tracking-normal uppercase"
+                                >
                                     Steps/day
                                 </label>
                             </s:partial:components.ui.form.stepper>
@@ -318,7 +355,12 @@
                             </div>
                         </div>
                         <div>
-                            <s:partial:components.ui.button variant="secondary" type="button" as="button" class="w-full">
+                            <s:partial:components.ui.button
+                                variant="secondary"
+                                type="button"
+                                as="button"
+                                class="w-full"
+                            >
                                 Set Goal
                             </s:partial:components.ui.button>
                         </div>
@@ -332,30 +374,15 @@
                 <div class="card shadow-none">
                     <div class="card__header">
                         <p class="text-xl font-semibold">FAQs</p>
-                        <p class="text-muted-foreground text-sm">Here are some of the most frequently asked questions.</p>
+                        <p class="text-muted-foreground text-sm">
+                            Here are some of the most frequently asked questions.
+                        </p>
                     </div>
 
-                    {{ demo_faqs = [
-                        [
-                            'question' => 'How long does a project take?',
-                            'answer' => 'Project timelines vary based on complexity, but most websites take 4-8 weeks from start to finish.',
-                        ],
-                        [
-                            'question' => 'Do you offer maintenance?',
-                            'answer' => 'Yes, we provide ongoing maintenance and support packages to keep your website running smoothly.',
-                        ],
-                        [
-                            'question' => 'How do I get started?',
-                            'answer' => 'Contact us to discuss your project and we’ll provide a free consultation to help you get started.',
-                        ],
-                    ] }}
-
+                    {{ demo_faqs = [['question' => 'How long does a project take?', 'answer' => 'Project timelines vary based on complexity, but most websites take 4-8 weeks from start to finish.', ], ['question' => 'Do you offer maintenance?', 'answer' => 'Yes, we provide ongoing maintenance and support packages to keep your website running smoothly.', ], ['question' => 'How do I get started?', 'answer' => 'Contact us to discuss your project and we’ll provide a free consultation to help you get started.', ], ] }}
                     <dl class="space-y-2">
                         {{ demo_faqs }}
-                            {{ partial:components/ui/collapsible
-                                trigger_class="flex w-full items-center justify-between py-2 text-left text-sm font-medium"
-                                content_class="text-muted-foreground text-sm"
-                            }}
+                            {{ partial:components/ui/collapsible trigger_class="flex w-full items-center justify-between py-2 text-left text-sm font-medium" content_class="text-muted-foreground text-sm" }}
                                 {{ slot:trigger }}
                                     {{ question }}
                                     <s:svg
@@ -383,7 +410,9 @@
                     <div class="flex items-center justify-between">
                         <div>
                             <p class="text-sm font-medium">Share bedrock</p>
-                            <p class="text-muted-foreground text-sm">Share this starter-kit with your followers</p>
+                            <p class="text-muted-foreground text-sm">
+                                Share this starter-kit with your followers
+                            </p>
                         </div>
                         {{ partial:components/ui/dialog size="sm" trigger_class="btn--outline btn--sm" }}
                             {{ slot:trigger }}
@@ -392,12 +421,24 @@
                             {{ slot:content }}
                                 <div class="flex flex-col gap-4">
                                     <div class="flex flex-col gap-2 text-center sm:text-left">
-                                        <p class="text-lg leading-none font-semibold text-neutral-800">Share link</p>
-                                        <p class="text-muted-foreground text-sm">Anyone who has this link will be able to view this.</p>
+                                        <p
+                                            class="text-lg leading-none font-semibold text-neutral-800"
+                                        >
+                                            Share link
+                                        </p>
+                                        <p class="text-muted-foreground text-sm">
+                                            Anyone who has this link will be able to view this.
+                                        </p>
                                     </div>
                                     <div class="flex items-center gap-2">
                                         <label for="link" class="sr-only">Link</label>
-                                        <input type="text" id="link" class="input" readonly value="https://bedrock.remarkable.dev" />
+                                        <input
+                                            type="text"
+                                            id="link"
+                                            class="input"
+                                            readonly
+                                            value="https://bedrock.remarkable.dev"
+                                        />
                                         <s:partial:components.ui.button
                                             variant="outline"
                                             as="button"
@@ -431,23 +472,37 @@
                         {{ partial:components/ui/dropdown/dropdown alignment="right" width="w-48" toggle_class="btn--outline btn--sm" }}
                             {{ slot:toggle }}
                                 Actions
-                                <s:svg src="lucide/chevron-down" class="mt-px -mr-1 size-4 opacity-50" />
+                                <s:svg
+                                    src="lucide/chevron-down"
+                                    class="mt-px -mr-1 size-4 opacity-50"
+                                />
                             {{ /slot:toggle }}
-
                             {{ slot:content }}
-                                <s:partial:components.ui.dropdown.item href="/" @click.prevent="close()">
+                                <s:partial:components.ui.dropdown.item
+                                    href="/"
+                                    @click.prevent="close()"
+                                >
                                     <s:svg src="lucide/edit" />
                                     Edit Content
                                 </s:partial:components.ui.dropdown.item>
-                                <s:partial:components.ui.dropdown.item href="/" @click.prevent="close()">
+                                <s:partial:components.ui.dropdown.item
+                                    href="/"
+                                    @click.prevent="close()"
+                                >
                                     <s:svg src="lucide/share-2" />
                                     Share Page
                                 </s:partial:components.ui.dropdown.item>
-                                <s:partial:components.ui.dropdown.item href="/" @click.prevent="close()">
+                                <s:partial:components.ui.dropdown.item
+                                    href="/"
+                                    @click.prevent="close()"
+                                >
                                     <s:svg src="lucide/download" />
                                     Export Data
                                 </s:partial:components.ui.dropdown.item>
-                                <s:partial:components.ui.dropdown.item href="/" @click.prevent="close()">
+                                <s:partial:components.ui.dropdown.item
+                                    href="/"
+                                    @click.prevent="close()"
+                                >
                                     <s:svg src="lucide/settings" />
                                     Settings
                                 </s:partial:components.ui.dropdown.item>
@@ -488,11 +543,46 @@
                     </div>
 
                     <div class="flex flex-wrap gap-3">
-                        <button class="btn btn--outline" x-data type="button" @click="$dispatch('toast', &#123; message: 'Saved!', description: 'Anyone with a link can now view this file.', type: 'success', dismissible: true &#125;)">Success</button>
-                        <button class="btn btn--outline" x-data type="button" @click="$dispatch('toast', &#123; message: 'There was an error!', type: 'error' &#125;)">Error</button>
-                        <button class="btn btn--outline" x-data type="button" @click="$dispatch('toast', &#123; message: 'This is a warning', type: 'warning' &#125;)">Warning</button>
-                        <button class="btn btn--outline" x-data type="button" @click="$dispatch('toast', &#123; message: 'This is an info message', type: 'info' &#125;)">Info</button>
-                        <button class="btn btn--outline" x-data type="button" @click="$dispatch('toast', &#123; message: 'This is a default toast' &#125;)">Default</button>
+                        <button
+                            class="btn btn--outline"
+                            x-data
+                            type="button"
+                            @click="$dispatch('toast', &#123; message: 'Saved!', description: 'Anyone with a link can now view this file.', type: 'success', dismissible: true &#125;)"
+                        >
+                            Success
+                        </button>
+                        <button
+                            class="btn btn--outline"
+                            x-data
+                            type="button"
+                            @click="$dispatch('toast', &#123; message: 'There was an error!', type: 'error' &#125;)"
+                        >
+                            Error
+                        </button>
+                        <button
+                            class="btn btn--outline"
+                            x-data
+                            type="button"
+                            @click="$dispatch('toast', &#123; message: 'This is a warning', type: 'warning' &#125;)"
+                        >
+                            Warning
+                        </button>
+                        <button
+                            class="btn btn--outline"
+                            x-data
+                            type="button"
+                            @click="$dispatch('toast', &#123; message: 'This is an info message', type: 'info' &#125;)"
+                        >
+                            Info
+                        </button>
+                        <button
+                            class="btn btn--outline"
+                            x-data
+                            type="button"
+                            @click="$dispatch('toast', &#123; message: 'This is a default toast' &#125;)"
+                        >
+                            Default
+                        </button>
                     </div>
                 </div>
             </div>

--- a/export/resources/views/blocks/newsletter.antlers.html
+++ b/export/resources/views/blocks/newsletter.antlers.html
@@ -1,6 +1,6 @@
 {{#
-    Configure newsletter content inside Control Panel in /cp/globals/newsletter
-    Configure email service provider logic inside app/Http/Controllers/NewsletterController.php
+    Configure newsletter content inside Control Panel in /cp/globals/newsletter Configure email service
+    provider logic inside app/Http/Controllers/NewsletterController.php
 #}}
 
 {{ once }}
@@ -8,7 +8,6 @@
         <s:vite src="resources/js/components/newsletter.js" />
     {{ /push:scripts }}
 {{ /once }}
-
 <div
     x-cloak
     x-show="!isSubscribed"
@@ -55,7 +54,12 @@
                     :placeholder="newsletter:input_placeholder"
                 />
 
-                <s:partial:components.ui.button class="shrink-0 sm:w-auto" type="submit" as="button" :label="newsletter:button_label" />
+                <s:partial:components.ui.button
+                    class="shrink-0 sm:w-auto"
+                    type="submit"
+                    as="button"
+                    :label="newsletter:button_label"
+                />
             </div>
 
             <s:partial:components.ui.input-error handle="email" id="{type}-email" />

--- a/export/resources/views/blocks/search-results.antlers.html
+++ b/export/resources/views/blocks/search-results.antlers.html
@@ -3,16 +3,9 @@
         <s:partial:components.section-header :title="title" :text="text" />
 
         {{#
-            You can set index in config/statamic/search.php
-            Docs: https://statamic.dev/search#indexes
-        #}}
-        <s:search:results
-            index="blog"
-            :limit="limit"
-            paginate="true"
-            on_each_side="1"
-            as="results"
-        >
+    You can set index in config/statamic/search.php Docs: https://statamic.dev/search#indexes
+#}}
+        <s:search:results index="blog" :limit="limit" paginate="true" on_each_side="1" as="results">
             <div class="site-grid gap-y-20 md:gap-y-12">
                 <div class="max-w-md sm:col-span-12">
                     <s:partial:components.search-form
@@ -20,7 +13,6 @@
                         :total_results="paginate:total_items ?? 0"
                     />
                 </div>
-
                 {{ if results | count > 0 }}
                     {{ results }}
                         <s:partial:components.entry-posts
@@ -39,7 +31,6 @@
                     </div>
                 {{ /if }}
             </div>
-
             {{ if paginate }}
                 <s:partial:components.ui.pagination.pagination class="mt-20" :paginate="paginate" />
             {{ /if }}

--- a/export/resources/views/blocks/style-guide.antlers.html
+++ b/export/resources/views/blocks/style-guide.antlers.html
@@ -84,9 +84,20 @@
                 <s:partial:partials.style-guide.button-row variant="destructive" />
                 <s:partial:partials.style-guide.button-row variant="ghost" />
                 <div class="flex flex-col gap-y-6 md:flex-row md:items-end">
-                    <dt class="content-sm text-muted-foreground shrink-0 font-mono leading-6 md:w-44">btn--link</dt>
-                    <dd class="flex flex-col items-start justify-start gap-6 md:flex-row md:items-end">
-                        <s:partial:components.ui.button variant="link" label="Get started" link_type="url" url="/" />
+                    <dt
+                        class="content-sm text-muted-foreground shrink-0 font-mono leading-6 md:w-44"
+                    >
+                        btn--link
+                    </dt>
+                    <dd
+                        class="flex flex-col items-start justify-start gap-6 md:flex-row md:items-end"
+                    >
+                        <s:partial:components.ui.button
+                            variant="link"
+                            label="Get started"
+                            link_type="url"
+                            url="/"
+                        />
                     </dd>
                 </div>
             </dl>
@@ -112,18 +123,26 @@
             </div>
             <dl class="space-y-10">
                 <div class="flex items-center">
-                    <dt class="content-sm text-muted-foreground w-32 shrink-0 font-mono leading-6">badge</dt>
+                    <dt class="content-sm text-muted-foreground w-32 shrink-0 font-mono leading-6">
+                        badge
+                    </dt>
                     <dd class="flex flex-wrap gap-3">
-                        <s:partial:components.ui.badge variant="primary">Primary</s:partial:components.ui.badge>
+                        <s:partial:components.ui.badge variant="primary">
+                            Primary
+                        </s:partial:components.ui.badge>
                         <a href="/" class="badge badge--secondary">
                             Secondary
                             <s:svg src="lucide/arrow-right" />
                         </a>
-                        <s:partial:components.ui.badge variant="outline">Outline</s:partial:components.ui.badge>
+                        <s:partial:components.ui.badge variant="outline">
+                            Outline
+                        </s:partial:components.ui.badge>
                     </dd>
                 </div>
                 <div class="flex items-center">
-                    <dt class="content-sm text-muted-foreground w-32 shrink-0 font-mono leading-6">tagline</dt>
+                    <dt class="content-sm text-muted-foreground w-32 shrink-0 font-mono leading-6">
+                        tagline
+                    </dt>
                     <dd class="tagline text-primary truncate">The quick brown fox</dd>
                 </div>
                 <s:partial:partials.style-guide.content-row size="content-xl" />

--- a/export/resources/views/blocks/team.antlers.html
+++ b/export/resources/views/blocks/team.antlers.html
@@ -1,7 +1,6 @@
 <section id="{{ type | slugify }}" class="m-section">
     <div class="container">
         <s:partial:components.section-header :title="title" :text="text" />
-
         {{ if query == 'custom' }}
             {{ team_members = entries }}
         {{ elseif query == 'ordered' }}
@@ -9,12 +8,19 @@
         {{ elseif query == 'featured' }}
             {{ team_members = {collection:team :limit="limit" featured="true" sort="order"} }}
         {{ /if }}
-
         <div class="site-grid gap-y-20">
             {{ team_members }}
                 <div class="sm:col-span-6 lg:col-span-4">
-                    <div class="aspect-3/2 rounded-2xl bg-gray-100 ring-1 ring-gray-900/10 ring-inset">
-                        <s:partial:components.ui.picture :image="image" w="384" h="256" cover="true" class="rounded-2xl" />
+                    <div
+                        class="aspect-3/2 rounded-2xl bg-gray-100 ring-1 ring-gray-900/10 ring-inset"
+                    >
+                        <s:partial:components.ui.picture
+                            :image="image"
+                            w="384"
+                            h="256"
+                            cover="true"
+                            class="rounded-2xl"
+                        />
                     </div>
                     <h3 class="h5 mt-6">{{ title }}</h3>
                     <p class="text-muted-foreground">{{ position }}</p>

--- a/export/resources/views/blocks/testimonials.antlers.html
+++ b/export/resources/views/blocks/testimonials.antlers.html
@@ -1,7 +1,6 @@
 <section id="{{ type | slugify }}" class="m-section">
     <div class="container">
         <s:partial:components.section-header :title="title" :text="text" />
-
         {{ if query == 'custom' }}
             {{ testimonials = entries }}
         {{ elseif query == 'latest' }}
@@ -9,7 +8,6 @@
         {{ elseif query == 'featured' }}
             {{ testimonials = {collection:testimonials :limit="limit" featured="true" sort="order"} }}
         {{ /if }}
-
         <div class="site-grid">
             {{ testimonials }}
                 <div class="sm:col-span-6 lg:col-span-4">

--- a/export/resources/views/components/breadcrumbs.antlers.html
+++ b/export/resources/views/components/breadcrumbs.antlers.html
@@ -2,15 +2,12 @@
 class: ''
 ---
 
-<nav aria-label="breadcrumb" class="max-w-[calc(100vw-48px)] overflow-hidden {{ view:class }}">
+<nav aria-label="breadcrumb" class="{{ view:class }} max-w-[calc(100vw-48px)] overflow-hidden">
     <ol class="text-muted-foreground flex gap-1.5 text-sm sm:gap-2.5">
         <s:nav:breadcrumbs>
-            <li class="flex items-center gap-1.5 {{ last ?= 'truncate' }}">
+            <li class="{{ last ?= 'truncate' }} flex items-center gap-1.5">
                 {{ unless last }}
-                    <a
-                        href="{{ url }}"
-                        class="hover:text-foreground whitespace-nowrap"
-                    >
+                    <a href="{{ url }}" class="hover:text-foreground whitespace-nowrap">
                         <span>{{ title }}</span>
                     </a>
                     <s:svg src="lucide/chevron-right" class="size-3.5 shrink-0" />

--- a/export/resources/views/components/cp-toolbar.antlers.html
+++ b/export/resources/views/components/cp-toolbar.antlers.html
@@ -1,6 +1,7 @@
 {{#
-    Show the edit entry button if the user has the permission. i.e. shown only for logged in users with a permission.
-    Wrapped in <s:nocache> so it works with static caching enabled.
+    Show the edit entry button if the user has the permission. i.e. shown only for logged in users with
+    a permission. Wrapped in
+    <s:nocache>so it works with static caching enabled.</s:nocache>
 #}}
 
 <s:nocache select="collection:handle|environment|edit_url">

--- a/export/resources/views/components/entry-meta.antlers.html
+++ b/export/resources/views/components/entry-meta.antlers.html
@@ -4,7 +4,7 @@ category: ''
 class: ''
 ---
 
-<div class="flex items-center gap-4 {{ view:class }}">
+<div class="{{ view:class }} flex items-center gap-4">
     <time datetime="{{ view:date | format('c') }}" class="text-muted-foreground text-xs">
         {{ view:date | format('M j, Y') }}
     </time>

--- a/export/resources/views/components/entry-posts.antlers.html
+++ b/export/resources/views/components/entry-posts.antlers.html
@@ -6,7 +6,13 @@ class: ''
     <div
         class="aspect-video rounded-2xl bg-gray-100 ring-1 ring-gray-900/10 ring-inset lg:aspect-3/2"
     >
-        <s:partial:components.ui.picture :image="image" w="672" h="378" cover="true" class="rounded-2xl" />
+        <s:partial:components.ui.picture
+            :image="image"
+            w="672"
+            h="378"
+            cover="true"
+            class="rounded-2xl"
+        />
     </div>
 
     <s:partial:components.entry-meta :date="date" :category="categories:title" class="mt-8" />

--- a/export/resources/views/components/entry-testimonials.antlers.html
+++ b/export/resources/views/components/entry-testimonials.antlers.html
@@ -3,7 +3,7 @@ fetched_from_rest_api: false
 class: ''
 ---
 
-<figure class="bg-primary-foreground rounded-2xl p-8 text-sm/6 {{ view:class }}">
+<figure class="bg-primary-foreground {{ view:class }} rounded-2xl p-8 text-sm/6">
     <blockquote class="text-neutral-900">
         {{ if view:fetched_from_rest_api }}
             <p x-html="`“${entry.quote}”`"></p>

--- a/export/resources/views/components/faqs-item.antlers.html
+++ b/export/resources/views/components/faqs-item.antlers.html
@@ -4,11 +4,7 @@ text: ''
 class: ''
 ---
 
-{{ partial:components/ui/collapsible
-    class="group {view:class}"
-    trigger_class="flex w-full items-center justify-between gap-x-6 py-6 text-left underline-offset-4 hover:underline"
-    content_class="-top-2 pr-12"
-}}
+{{ partial:components/ui/collapsible class="group {view:class}" trigger_class="flex w-full items-center justify-between gap-x-6 py-6 text-left underline-offset-4 hover:underline" content_class="-top-2 pr-12" }}
     {{ slot:trigger }}
         <span class="content-lg font-medium text-neutral-900">{{ view:title }}</span>
         <span class="size-6 flex-none text-neutral-800/70" aria-hidden="true">
@@ -16,7 +12,6 @@ class: ''
             <s:svg src="lucide/minus" x-show="open" />
         </span>
     {{ /slot:trigger }}
-
     {{ slot:content }}
         <div class="content-sm prose text-muted-foreground max-w-none pb-4 text-pretty">
             {{ view:text }}

--- a/export/resources/views/components/faqs.antlers.html
+++ b/export/resources/views/components/faqs.antlers.html
@@ -6,7 +6,6 @@ class: ''
 <dl {{ view:class | attribute:class }}>
     {{ slot }}
 </dl>
-
 {{ if view:items }}
     {{ section:json_ld }}
         <script type="application/ld+json" id="schema-faq">

--- a/export/resources/views/components/form-field.antlers.html
+++ b/export/resources/views/components/form-field.antlers.html
@@ -1,12 +1,12 @@
 ---
 fields_without_label:
-  - radio
-  - toggle
-  - checkboxes
-  - stepper
+  - 'radio'
+  - 'toggle'
+  - 'checkboxes'
+  - 'stepper'
 fields_without_error:
-  - section
-  - spacer
+  - 'section'
+  - 'spacer'
 ---
 
 {{#
@@ -15,7 +15,6 @@ fields_without_error:
     field variables in scope: type, handle, id, display, instructions, input_type, width, show_field,
     options, etc.
 #}}
-
 {{ if type === 'hidden_input' }}
     <input
         type="hidden"
@@ -29,22 +28,27 @@ fields_without_error:
             class="{{ ['md:col-span-3' => width == '25', 'md:col-span-4' => width == '33', 'md:col-span-6' => width == '50', 'md:col-span-8' => width == '66', 'md:col-span-9' => width == '75', 'md:col-span-12' => width == '100'] | classes }} grid content-start gap-3"
         >
             {{ unless view:fields_without_label | contains(type) }}
-                <s:partial:components.ui.label :display="display" :id="id" :hide_display="hide_display" />
+                <s:partial:components.ui.label
+                    :display="display"
+                    :id="id"
+                    :hide_display="hide_display"
+                />
             {{ /unless }}
-
             <div class="grid gap-2">
                 {{ show_instructions = instructions && !(view:fields_without_label | contains(type)) }}
-
                 {{ if show_instructions && instructions_position === 'above' }}
-                    <s:partial:components.ui.input-instructions :instructions="instructions" :id="id" />
+                    <s:partial:components.ui.input-instructions
+                        :instructions="instructions"
+                        :id="id"
+                    />
                 {{ /if }}
-
                 <s:partial src="components.ui.form.{type}" model="form.{handle}" />
-
                 {{ if show_instructions && instructions_position === 'below' }}
-                    <s:partial:components.ui.input-instructions :instructions="instructions" :id="id" />
+                    <s:partial:components.ui.input-instructions
+                        :instructions="instructions"
+                        :id="id"
+                    />
                 {{ /if }}
-
                 {{ unless view:fields_without_error | contains(type) }}
                     <s:partial:components.ui.input-error :handle="handle" :id="id" />
                 {{ /unless }}

--- a/export/resources/views/components/form.antlers.html
+++ b/export/resources/views/components/form.antlers.html
@@ -5,15 +5,11 @@ submit_label: 'Submit'
 ---
 
 {{#
-    Component for outputting Statamic form fields grouped in sections. We keep the form field
-    components inside the views/components/ui/form folder instead of publishing and customizing a
-    vendor folder like the docs suggest: https://statamic.dev/tags/form-create#prerendered-field-html
-    This gives us more control over the form fields and allows us to reuse the same form fields
-    outside of the Statamic form.
-
-    Docs:
-    https://statamic.dev/forms
-    https://statamic.dev/tags/form-create
+    Component for outputting Statamic form fields grouped in sections. We keep the form field components
+    inside the views/components/ui/form folder instead of publishing and customizing a vendor folder
+    like the docs suggest: https://statamic.dev/tags/form-create#prerendered-field-html This gives us
+    more control over the form fields and allows us to reuse the same form fields outside of the
+    Statamic form. Docs: https://statamic.dev/forms https://statamic.dev/tags/form-create
 #}}
 
 {{ once }}
@@ -22,7 +18,6 @@ submit_label: 'Submit'
         <s:vite src="resources/js/components/statamicForm.js" />
     {{ /push:scripts }}
 {{ /once }}
-
 <s:form:create
     :in="view:form_handle"
     id="form-{view:form_handle}"

--- a/export/resources/views/components/logo.antlers.html
+++ b/export/resources/views/components/logo.antlers.html
@@ -6,7 +6,6 @@ class: ''
 ---
 
 {{# Set the logo inside Control Panel in /cp/globals/theme #}}
-
 <a
     href="{{ view:url ? view:url : config:app:url }}"
     aria-label="{{ view:aria_label ? view:aria_label : '{config:app:name} logo' }}"

--- a/export/resources/views/components/search-form.antlers.html
+++ b/export/resources/views/components/search-form.antlers.html
@@ -7,12 +7,15 @@ class: ''
 ---
 
 {{#
-    Set the search results URL inside Control Panel in /cp/globals/theme
-
-    Docs: https://statamic.dev/search#forms
+    Set the search results URL inside Control Panel in /cp/globals/theme Docs:
+    https://statamic.dev/search#forms
 #}}
 
-<form class="flex items-center gap-6 {{ view:class }}" action="{{ view:action }}" x-data="{ search: '{{ view:query ? view:query : get:q | sanitize }}' }">
+<form
+    class="{{ view:class }} flex items-center gap-6"
+    action="{{ view:action }}"
+    x-data="{ search: '{{ view:query ? view:query : get:q | sanitize }}' }"
+>
     <div class="text-foreground relative flex-1">
         <input
             x-model="search"
@@ -39,7 +42,8 @@ class: ''
     </div>
     {{ if view:query }}
         <span class="shrink-0 font-semibold">
-            {{ view:total_results }} {{ 'result' | plural(view:total_results) }}
+            {{ view:total_results }}
+            {{ 'result' | plural(view:total_results) }}
         </span>
     {{ /if }}
 </form>

--- a/export/resources/views/components/section-header.antlers.html
+++ b/export/resources/views/components/section-header.antlers.html
@@ -5,9 +5,8 @@ margin: 'mb-20'
 class: ''
 ---
 
-<div class="mx-auto max-w-xl text-center {{ view:margin }} {{ view:class }}">
+<div class="{{ view:margin }} {{ view:class }} mx-auto max-w-xl text-center">
     <h2 class="h2 text-pretty">{{ view:title }}</h2>
-
     {{ if view:text }}
         <p class="text-muted-foreground mt-6 text-lg text-pretty">{{ view:text }}</p>
     {{ /if }}

--- a/export/resources/views/components/ui/alert.antlers.html
+++ b/export/resources/views/components/ui/alert.antlers.html
@@ -28,7 +28,6 @@ class: ''
             <p class="text-muted-foreground text-sm">{{ view:description }}</p>
         {{ /if }}
     </div>
-
     {{ if view:dismissible }}
         <div class="ml-auto pl-2">
             <div class="-m-2">

--- a/export/resources/views/components/ui/avatar.antlers.html
+++ b/export/resources/views/components/ui/avatar.antlers.html
@@ -6,7 +6,7 @@ name: ''
 class: ''
 ---
 
-<div class="bg-primary-foreground shrink-0 overflow-hidden rounded-full {{ view:class }}">
+<div class="bg-primary-foreground {{ view:class }} shrink-0 overflow-hidden rounded-full">
     <s:glide :src="view:image" :width="view:w" :height="view:h" dpr="2" fit="crop_focal">
         <img src="{{ url }}" alt="{{ view:name }}’s avatar" loading="lazy" />
     </s:glide>

--- a/export/resources/views/components/ui/banner.antlers.html
+++ b/export/resources/views/components/ui/banner.antlers.html
@@ -1,6 +1,6 @@
 {{#
-    Configure Banner inside Control Panel in /cp/globals/banner
-    Relies on a tiny `js-cookie` npm package for setting and getting cookies.
+    Configure Banner inside Control Panel in /cp/globals/banner Relies on a tiny `js-cookie` npm package
+    for setting and getting cookies.
 #}}
 
 <div

--- a/export/resources/views/components/ui/carousel/carousel.antlers.html
+++ b/export/resources/views/components/ui/carousel/carousel.antlers.html
@@ -6,8 +6,7 @@ content_class: ''
 ---
 
 {{#
-    Carousel component similar to shadcn/ui carousel
-    Uses Embla Carousel with Alpine.js state management
+    Carousel component similar to shadcn/ui carousel Uses Embla Carousel with Alpine.js state management
     Available options: https://www.embla-carousel.com/api/options/
 #}}
 
@@ -16,9 +15,8 @@ content_class: ''
         <s:vite src="resources/js/embla.js" />
     {{ /push:scripts }}
 {{ /once }}
-
 <div
-    class="relative outline-none {{ view:class }}"
+    class="{{ view:class }} relative outline-none"
     role="region"
     aria-roledescription="carousel"
     x-data="{
@@ -61,7 +59,7 @@ content_class: ''
 >
     <div x-ref="viewport" class="overflow-hidden">
         <div
-            class="flex {{ view:content_class }}"
+            class="{{ view:content_class }} flex"
             :class="{
                 '-ml-4': orientation === 'horizontal',
                 '-mt-4 flex-col': orientation === 'vertical',

--- a/export/resources/views/components/ui/carousel/next.antlers.html
+++ b/export/resources/views/components/ui/carousel/next.antlers.html
@@ -3,7 +3,7 @@ class: ''
 ---
 
 <button
-    class="btn absolute {{ view:class }}"
+    class="btn {{ view:class }} absolute"
     :class="{
         'top-1/2 -right-12 -translate-y-1/2': orientation === 'horizontal',
         '-bottom-12 left-1/2 -translate-x-1/2 rotate-90': orientation === 'vertical',

--- a/export/resources/views/components/ui/carousel/previous.antlers.html
+++ b/export/resources/views/components/ui/carousel/previous.antlers.html
@@ -3,7 +3,7 @@ class: ''
 ---
 
 <button
-    class="btn absolute {{ view:class }}"
+    class="btn {{ view:class }} absolute"
     :class="{
         'top-1/2 -left-12 -translate-y-1/2': orientation === 'horizontal',
         '-top-12 left-1/2 -translate-x-1/2 rotate-90': orientation === 'vertical',

--- a/export/resources/views/components/ui/carousel/slide.antlers.html
+++ b/export/resources/views/components/ui/carousel/slide.antlers.html
@@ -3,7 +3,7 @@ class: ''
 ---
 
 <div
-    class="min-w-0 shrink-0 grow-0 basis-full {{ view:class }}"
+    class="{{ view:class }} min-w-0 shrink-0 grow-0 basis-full"
     role="group"
     aria-roledescription="slide"
     :class="{

--- a/export/resources/views/components/ui/collapsible.antlers.html
+++ b/export/resources/views/components/ui/collapsible.antlers.html
@@ -15,7 +15,7 @@ content_class: ''
             this.open = false
         },
     }"
-    class="relative {{ view:class }}"
+    class="{{ view:class }} relative"
 >
     <dt>
         <button
@@ -38,7 +38,7 @@ content_class: ''
         id="collapsible-{{ view:name }}"
         role="region"
         :aria-hidden="!open"
-        class="relative {{ view:content_class }}"
+        class="{{ view:content_class }} relative"
     >
         {{ slot:content }}
     </dd>

--- a/export/resources/views/components/ui/dialog.antlers.html
+++ b/export/resources/views/components/ui/dialog.antlers.html
@@ -70,11 +70,10 @@ content_class: ''
             {{ slot:trigger }}
         </button>
     {{ /if }}
-
     {{#
-        Uses the Alpine.js teleport directive, which will teleport the Dialog
-        element to be a child of the body element. This allows the dialog
-        to be full-screen and prevents any display issues with its parent elements.
+        Uses the Alpine.js teleport directive, which will teleport the Dialog element to be a child of the
+        body element. This allows the dialog to be full-screen and prevents any display issues with its
+        parent elements.
     #}}
     <template x-teleport="body">
         <div
@@ -117,10 +116,9 @@ content_class: ''
                         x-transition:leave-end="translate-y-4 opacity-0 sm:translate-y-0 sm:scale-95"
                         @click.outside="close($refs.button)"
                         :id="id"
-                        class="bg-background relative transform overflow-hidden rounded-[0.625rem] border text-left shadow-lg transition-all sm:my-8 sm:w-full {{ ['px-4 pt-5 pb-4 sm:max-w-md sm:p-6' => view:size == 'sm', 'px-4 pt-5 pb-4 sm:max-w-xl sm:p-6' => view:size == 'md', 'px-4 pt-5 pb-4 sm:max-w-(--breakpoint-xl) sm:p-6 md:p-12 xl:px-16 xl:py-20' => view:size == 'xl'] | classes }} {{ view:content_class }}"
+                        class="bg-background {{ ['px-4 pt-5 pb-4 sm:max-w-md sm:p-6' => view:size == 'sm', 'px-4 pt-5 pb-4 sm:max-w-xl sm:p-6' => view:size == 'md', 'px-4 pt-5 pb-4 sm:max-w-(--breakpoint-xl) sm:p-6 md:p-12 xl:px-16 xl:py-20' => view:size == 'xl'] | classes }} {{ view:content_class }} relative transform overflow-hidden rounded-[0.625rem] border text-left shadow-lg transition-all sm:my-8 sm:w-full"
                     >
                         {{ slot:content }}
-
                         <button
                             @click="close($refs.button)"
                             class="btn hover:text-foreground absolute top-4 right-4 size-6 rounded-xs text-neutral-800/70"

--- a/export/resources/views/components/ui/dropdown/dropdown.antlers.html
+++ b/export/resources/views/components/ui/dropdown/dropdown.antlers.html
@@ -25,7 +25,7 @@ content_class: ''
     @keydown.escape.prevent.stop="close($refs.button)"
     @focusin.window="!$refs.panel.contains($event.target) && close()"
     x-id="['dropdown-menu']"
-    class="relative {{ view:class }}"
+    class="{{ view:class }} relative"
 >
     <button
         x-ref="button"
@@ -52,7 +52,7 @@ content_class: ''
         :id="$id('dropdown-menu')"
         :aria-labelledby="$id('dropdown-button')"
         tabindex="-1"
-        class="bg-popover text-popover-foreground absolute z-10 mt-1 max-h-60 overflow-x-hidden overflow-y-auto rounded-lg border p-1 shadow-md {{ ['left-0 origin-top-left' => view:alignment == 'left', 'right-0 origin-top-right' => view:alignment == 'right'] | classes }} {{ view:width }} {{ view:content_class }}"
+        class="bg-popover text-popover-foreground {{ ['left-0 origin-top-left' => view:alignment == 'left', 'right-0 origin-top-right' => view:alignment == 'right'] | classes }} {{ view:width }} {{ view:content_class }} absolute z-10 mt-1 max-h-60 overflow-x-hidden overflow-y-auto rounded-lg border p-1 shadow-md"
     >
         {{ slot:content }}
     </div>

--- a/export/resources/views/components/ui/dropdown/item.antlers.html
+++ b/export/resources/views/components/ui/dropdown/item.antlers.html
@@ -4,7 +4,7 @@ class: ''
 ---
 
 <{{ view:as }}
-    class="hover:bg-accent hover:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 {{ view:class }}"
+    class="hover:bg-accent hover:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground {{ view:class }} relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 >
     {{ slot }}
 </{{ view:as }}>

--- a/export/resources/views/components/ui/form/checkboxes.antlers.html
+++ b/export/resources/views/components/ui/form/checkboxes.antlers.html
@@ -9,11 +9,9 @@ class: ''
     :aria-describedby="form.invalid('{{ handle }}') ? '{{ id }}-error' : {{ if instructions }}'{{ id }}-instructions'{{ else }}false{{ /if }}"
 >
     <legend class="text-foreground block text-sm font-medium select-none">{{ display }}</legend>
-
     {{ if instructions }}
         <s:partial:components.ui.input-instructions :instructions="instructions" :id="id" />
     {{ /if }}
-
     <div class="mt-3 space-y-4">
         {{ foreach:options as="option|label" }}
             <div class="flex items-center gap-3">

--- a/export/resources/views/components/ui/form/combobox.antlers.html
+++ b/export/resources/views/components/ui/form/combobox.antlers.html
@@ -9,7 +9,6 @@ class: ''
         <s:vite src="resources/js/components/combobox.js" />
     {{ /push:scripts }}
 {{ /once }}
-
 <div
     x-data="combobox({
                 id: '{{ id }}',
@@ -20,7 +19,7 @@ class: ''
     x-model="{{ view:model }}"
     @keydown.escape.stop.prevent="closeListbox()"
     @change="form.validate('{{ handle }}')"
-    class="relative {{ view:class }}"
+    class="{{ view:class }} relative"
 >
     <input type="hidden" name="{{ handle }}" x-model="value" />
 

--- a/export/resources/views/components/ui/form/honeypot.antlers.html
+++ b/export/resources/views/components/ui/form/honeypot.antlers.html
@@ -5,7 +5,9 @@ form_handle: ''
 ---
 
 <div class="hidden">
-    <label for="{{ view:form_handle }}-{{ view:handle }}-field">{{ view:handle | deslugify | title }}</label>
+    <label for="{{ view:form_handle }}-{{ view:handle }}-field">
+        {{ view:handle | deslugify | title }}
+    </label>
     <input
         x-model="{{ view:model }}"
         id="{{ view:form_handle }}-{{ view:handle }}-field"

--- a/export/resources/views/components/ui/form/radio.antlers.html
+++ b/export/resources/views/components/ui/form/radio.antlers.html
@@ -9,11 +9,9 @@ class: ''
     :aria-describedby="form.invalid('{{ handle }}') ? '{{ id }}-error' : {{ if instructions }}'{{ id }}-instructions'{{ else }}false{{ /if }}"
 >
     <legend class="text-foreground block text-sm font-medium select-none">{{ display }}</legend>
-
     {{ if instructions }}
         <s:partial:components.ui.input-instructions :instructions="instructions" :id="id" />
     {{ /if }}
-
     <div class="mt-3 space-y-4">
         {{ foreach:options as="option|label" }}
             <div class="flex items-center gap-3">

--- a/export/resources/views/components/ui/form/select.antlers.html
+++ b/export/resources/views/components/ui/form/select.antlers.html
@@ -27,7 +27,6 @@ class: ''
                 Select {{ handle | deslugify | title }}…
             </option>
         {{ /unless }}
-
         {{ foreach:options as="option|label" }}
             <option value="{{ option }}">{{ label }}</option>
         {{ /foreach:options }}

--- a/export/resources/views/components/ui/form/stepper.antlers.html
+++ b/export/resources/views/components/ui/form/stepper.antlers.html
@@ -13,12 +13,13 @@ class: ''
         <s:vite src="resources/js/components/stepper.js" />
     {{ /push:scripts }}
 {{ /once }}
-
-<div class="{{ view:container_class }}" x-data="stepper({{ view:min }}, {{ view:max }}, {{ view:step }})">
+<div
+    class="{{ view:container_class }}"
+    x-data="stepper({{ view:min }}, {{ view:max }}, {{ view:step }})"
+>
     {{ unless slot }}
         <s:partial:components.ui.label :display="display" :id="id" />
     {{ /unless }}
-
     <div class="flex items-center gap-x-1">
         <button
             type="button"
@@ -32,14 +33,13 @@ class: ''
         >
             <s:svg src="lucide/minus" />
         </button>
-
         {{ if view:show_input }}
             <input
                 x-ref="input"
                 x-model="{{ view:model }}"
                 x-modelable="count"
                 id="{{ id }}"
-                class="[&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none size-8 border-none px-0 text-center shadow-none [-moz-appearance:textfield]"
+                class="size-8 border-none px-0 text-center shadow-none [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
                 name="{{ handle }}"
                 inputmode="numeric"
                 type="number"
@@ -54,7 +54,7 @@ class: ''
             />
         {{ elseif slot }}
             <input type="hidden" name="{{ handle }}" value="{{ view:model }}" />
-            <div class="text-center {{ view:class }}">
+            <div class="{{ view:class }} text-center">
                 <output
                     x-model="{{ view:model }}"
                     x-modelable="count"
@@ -65,7 +65,6 @@ class: ''
                 {{ slot }}
             </div>
         {{ /if }}
-
         <button
             type="button"
             class="btn btn--outline btn--sm btn--round shrink-0"

--- a/export/resources/views/components/ui/form/text.antlers.html
+++ b/export/resources/views/components/ui/form/text.antlers.html
@@ -9,7 +9,6 @@ class: ''
             <span class="text-muted-foreground text-sm">{{ prepend }}</span>
         </div>
     {{ /if }}
-
     <input
         x-model="{{ view:model }}"
         id="{{ id }}"
@@ -24,7 +23,6 @@ class: ''
         :aria-describedby="form.invalid('{{ handle }}') ? '{{ id }}-error' : {{ if instructions }}'{{ id }}-instructions'{{ else }}false{{ /if }}"
         @change="form.validate('{{ handle }}')"
     />
-
     {{ if append }}
         <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-5">
             <span class="text-muted-foreground text-sm">{{ append }}</span>

--- a/export/resources/views/components/ui/form/toggle.antlers.html
+++ b/export/resources/views/components/ui/form/toggle.antlers.html
@@ -4,7 +4,7 @@ class: ''
 ---
 
 <div
-    class="flex items-center gap-3 {{ view:class }}"
+    class="{{ view:class }} flex items-center gap-3"
     x-data="{
         on: false,
         toggle() {

--- a/export/resources/views/components/ui/input-error.antlers.html
+++ b/export/resources/views/components/ui/input-error.antlers.html
@@ -10,7 +10,7 @@ class: ''
         role="alert"
         aria-live="polite"
         aria-atomic="true"
-        class="text-destructive text-sm {{ view:class }}"
-        x-text="form.errors.{{ view:handle }}">
-    </p>
+        class="text-destructive {{ view:class }} text-sm"
+        x-text="form.errors.{{ view:handle }}"
+    ></p>
 </template>

--- a/export/resources/views/components/ui/input-instructions.antlers.html
+++ b/export/resources/views/components/ui/input-instructions.antlers.html
@@ -4,6 +4,6 @@ instructions: ''
 class: ''
 ---
 
-<p class="text-muted-foreground text-sm {{ view:class }}" id="{{ view:id }}-instructions">
+<p class="text-muted-foreground {{ view:class }} text-sm" id="{{ view:id }}-instructions">
     {{ view:instructions }}
 </p>

--- a/export/resources/views/components/ui/label.antlers.html
+++ b/export/resources/views/components/ui/label.antlers.html
@@ -7,7 +7,7 @@ class: 'text-foreground'
 
 <label
     id="{{ view:id }}-label"
-    class="block {{ view:class }} {{ view:hide_display ?= 'sr-only' }}"
+    class="{{ view:class }} {{ view:hide_display ?= 'sr-only' }} block"
     for="{{ view:id }}"
 >
     {{ view:display }}

--- a/export/resources/views/components/ui/pagination/item-current.antlers.html
+++ b/export/resources/views/components/ui/pagination/item-current.antlers.html
@@ -4,5 +4,7 @@ page: ''
 ---
 
 <li>
-    <a href="{{ view:url }}" class="btn btn--outline btn--square" aria-current="page">{{ view:page }}</a>
+    <a href="{{ view:url }}" class="btn btn--outline btn--square" aria-current="page">
+        {{ view:page }}
+    </a>
 </li>

--- a/export/resources/views/components/ui/pagination/pagination.antlers.html
+++ b/export/resources/views/components/ui/pagination/pagination.antlers.html
@@ -3,7 +3,6 @@ class: ''
 ---
 
 {{# Docs: https://statamic.dev/tags/collection#pagination #}}
-
 {{ if paginate:total_pages > 1 }}
     <div {{ view:class | attribute:class }}>
         {{# Section that will be yielded in the <head> of documents for search engines. #}}
@@ -15,11 +14,10 @@ class: ''
                 <link rel="next" href="{{ paginate:next_page }}" />
             {{ /if }}
         {{ /section:pagination }}
-
         <nav class="flex items-center justify-center gap-1 md:items-start">
             <a
                 href="{{ paginate:prev_page ?? 'javascript:void(0)' }}"
-                class="btn btn--ghost shrink-0 {{ paginate:prev_page ? '' : 'pointer-events-none opacity-50' }}"
+                class="btn btn--ghost {{ paginate:prev_page ? '' : 'pointer-events-none opacity-50' }} shrink-0"
             >
                 <s:svg src="lucide/chevron-left" class="size-4" />
                 <span class="sr-only md:not-sr-only">Previous</span>
@@ -33,11 +31,9 @@ class: ''
                         <s:partial:components.ui.pagination.item :url="url" :page="page" />
                     {{ /if }}
                 {{ /paginate:links:segments:first }}
-
                 {{ if paginate:links:segments:slider | length > 0 }}
                     <s:partial:components.ui.pagination.item-slider />
                 {{ /if }}
-
                 {{ paginate:links:segments:slider }}
                     {{ if page == paginate:current_page }}
                         <s:partial:components.ui.pagination.item-current :url="url" :page="page" />
@@ -45,11 +41,9 @@ class: ''
                         <s:partial:components.ui.pagination.item :url="url" :page="page" />
                     {{ /if }}
                 {{ /paginate:links:segments:slider }}
-
                 {{ if paginate:links:segments:slider | length > 0 or paginate:links:segments:last | length > 0 }}
                     <s:partial:components.ui.pagination.item-slider />
                 {{ /if }}
-
                 {{ paginate:links:segments:last }}
                     {{ if page == paginate:current_page }}
                         <s:partial:components.ui.pagination.item-current :url="url" :page="page" />
@@ -60,12 +54,13 @@ class: ''
             </ul>
 
             <p class="content-sm shrink-0 leading-none font-semibold md:hidden">
-                {{ paginate:current_page }} of {{ paginate:total_pages }}
+                {{ paginate:current_page }}
+                of {{ paginate:total_pages }}
             </p>
 
             <a
                 href="{{ paginate:next_page ?? 'javascript:void(0)' }}"
-                class="btn btn--ghost shrink-0 {{ paginate:next_page ? '' : 'pointer-events-none opacity-50' }}"
+                class="btn btn--ghost {{ paginate:next_page ? '' : 'pointer-events-none opacity-50' }} shrink-0"
             >
                 <span class="sr-only md:not-sr-only">Next</span>
                 <s:svg src="lucide/chevron-right" class="size-4" />

--- a/export/resources/views/components/ui/picture.antlers.html
+++ b/export/resources/views/components/ui/picture.antlers.html
@@ -9,14 +9,12 @@ fetchpriority: ''
 ---
 
 {{#
-    Lightweight picture component that uses Glide to generate images. It supports lazy loading and object-cover.
-    Notice that the component doesn't use sizes attribute, because in my opinion it's a waste of time.
-    Just pass the dimensions of the largest image size that needs rendered. Images are lazy loaded and saving a few kilobytes
-    on the initial load is not worth the extra complexity.
-
-    Docs: https://statamic.dev/tags/glide
+    Lightweight picture component that uses Glide to generate images. It supports lazy loading and
+    object-cover. Notice that the component doesn't use sizes attribute, because in my opinion it's a
+    waste of time. Just pass the dimensions of the largest image size that needs rendered. Images are
+    lazy loaded and saving a few kilobytes on the initial load is not worth the extra complexity. Docs:
+    https://statamic.dev/tags/glide
 #}}
-
 {{ if view:image }}
     <s:asset :url="view:image">
         <picture>

--- a/export/resources/views/components/ui/tabs/tabs.antlers.html
+++ b/export/resources/views/components/ui/tabs/tabs.antlers.html
@@ -3,7 +3,7 @@ class: ''
 list_class: ''
 ---
 
-<div x-data="{ activeTab: 1 }" class="flex flex-col gap-2 {{ view:class }}">
+<div x-data="{ activeTab: 1 }" class="{{ view:class }} flex flex-col gap-2">
     <div role="tablist" aria-orientation="horizontal" class="{{ view:list_class }}">
         {{ slot:list }}
     </div>

--- a/export/resources/views/components/ui/toaster.antlers.html
+++ b/export/resources/views/components/ui/toaster.antlers.html
@@ -3,7 +3,6 @@
         <s:vite src="resources/js/components/toaster.js" />
     {{ /push:scripts }}
 {{ /once }}
-
 <section
     x-data="toaster()"
     x-id="['toast']"

--- a/export/resources/views/layout.antlers.html
+++ b/export/resources/views/layout.antlers.html
@@ -1,57 +1,55 @@
 <!DOCTYPE html>
 <html lang="{{ site:short_locale }}">
-<head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
-    <s:partial:partials.seo />
-    <s:partial:partials.browser-appearance />
+        <s:partial:partials.seo />
+        <s:partial:partials.browser-appearance />
 
-    <s:vite src="resources/css/site.css" />
+        <s:vite src="resources/css/site.css" />
 
-    {{#
-        Async-load fonts:
-        1) Preload fonts.css (rel="preload" as="style") so it starts downloading early without applying.
-        2) Load again with media="print", then switch to media="all" onload to avoid render blocking.
-        With font-display: swap in fonts.css, fallback text paints immediately; the webfont swaps in when ready.
-    #}}
-    <s:vite src="resources/css/fonts.css" attr:style:rel="preload" attr:style:as="style" />
-    <s:vite
-        src="resources/css/fonts.css"
-        attr:style:media="print"
-        attr:style:onload="this.media='all'"
-    />
+        {{#
+            Async-load fonts: 1) Preload fonts.css (rel="preload" as="style") so it starts downloading early
+            without applying. 2) Load again with media="print", then switch to media="all" onload to avoid
+            render blocking. With font-display: swap in fonts.css, fallback text paints immediately; the webfont
+            swaps in when ready.
+        #}}
+        <s:vite src="resources/css/fonts.css" attr:style:rel="preload" attr:style:as="style" />
+        <s:vite
+            src="resources/css/fonts.css"
+            attr:style:media="print"
+            attr:style:onload="this.media='all'"
+        />
 
-    {{# Scripts global #}}
-    {{ scripts:code_head }}
-</head>
-<body
-    class="selection:bg-primary min-h-screen overflow-x-hidden bg-white font-sans text-base/6 text-neutral-800 antialiased selection:text-white"
->
-    <s:partial:partials.skip-to-content />
-    {{ yield:seo_body }}
+        {{# Scripts global #}}
+        {{ scripts:code_head }}
+    </head>
+    <body
+        class="selection:bg-primary min-h-screen overflow-x-hidden bg-white font-sans text-base/6 text-neutral-800 antialiased selection:text-white"
+    >
+        <s:partial:partials.skip-to-content />
+        {{ yield:seo_body }}
+        {{# Banner global #}}
+        {{ if banner:show }}
+            <s:partial:components.ui.banner />
+        {{ /if }}
+        <s:partial:partials.header />
+        {{ template_content }}
+        <s:partial:partials.footer />
 
-    {{# Banner global #}}
-    {{ if banner:show }}
-        <s:partial:components.ui.banner />
-    {{ /if }}
+        {{# Control panel toolbar #}}
+        <s:partial:components.cp-toolbar />
 
-    <s:partial:partials.header />
-    {{ template_content }}
-    <s:partial:partials.footer />
+        {{# Notifications #}}
+        <s:partial:components.ui.toaster />
 
-    {{# Control panel toolbar #}}
-    <s:partial:components.cp-toolbar />
+        {{# Push scripts when various components are added #}}
+        {{ stack:scripts }}
+        <s:vite src="resources/js/site.js" />
 
-    {{# Notifications #}}
-    <s:partial:components.ui.toaster />
-
-    {{# Push scripts when various components are added #}}
-    {{ stack:scripts }}
-    <s:vite src="resources/js/site.js" />
-
-    {{# Scripts global #}}
-    {{ scripts:code_footer }}
-</body>
+        {{# Scripts global #}}
+        {{ scripts:code_footer }}
+    </body>
 </html>

--- a/export/resources/views/partials/browser-appearance.antlers.html
+++ b/export/resources/views/partials/browser-appearance.antlers.html
@@ -1,33 +1,26 @@
 {{ if browser_appearance:disable_phone_detection }}
     <meta name="format-detection" content="telephone=no" />
 {{ /if }}
-
 {{ if browser_appearance:disable_email_detection }}
     <meta name="format-detection" content="email=no" />
 {{ /if }}
-
 {{ if browser_appearance:disable_address_detection }}
     <meta name="format-detection" content="address=no" />
 {{ /if }}
-
 {{ if browser_appearance:apple_mobile_web_app }}
     <meta name="apple-mobile-web-app-capable" content="yes" />
     {{ if browser_appearance:apple_status_bar_black }}
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     {{ /if }}
 {{ /if }}
-
 {{ if browser_appearance:android_mobile_web_app }}
     <meta name="mobile-web-app-capable" content="yes" />
 {{ /if }}
-
 {{ if browser_appearance:theme_color }}
     <meta name="theme-color" content="{{ browser_appearance:theme_color }}" />
 {{ /if }}
-
 {{#
-    Generate favicons here:
-    https://realfavicongenerator.net
+    Generate favicons here: https://realfavicongenerator.net
 #}}
 <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96" />
 <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg" />

--- a/export/resources/views/partials/cookie-dialog.antlers.html
+++ b/export/resources/views/partials/cookie-dialog.antlers.html
@@ -1,6 +1,6 @@
 {{#
-    Added in `resources/views/partials/seo.antlers.html` and rendered via the
-    {{ section:seo_body }} that the layout yields after opening <body>.
+    Added in `resources/views/partials/seo.antlers.html` and rendered via the `{{ section:seo_body }}`
+    tag that the layout yields after opening `body` tag.
 #}}
 
 {{ once }}
@@ -8,7 +8,6 @@
         <s:vite src="resources/js/components/cookieDialog.js" />
     {{ /push:scripts }}
 {{ /once }}
-
 <div
     x-cloak
     x-show="!$store.cookieDialog.getConsent()"
@@ -35,7 +34,7 @@
             {{ /if }}
         }
     })"
-    class="container fixed inset-x-0 bottom-0 z-50 max-w-xl pb-6"
+    class="fixed inset-x-0 bottom-0 z-50 container max-w-xl pb-6"
 >
     <div class="card shadow-lg transition-all">
         <div class="space-y-1.5">

--- a/export/resources/views/partials/nav-bottom-footer.antlers.html
+++ b/export/resources/views/partials/nav-bottom-footer.antlers.html
@@ -9,7 +9,6 @@
                 {{ title }}
             </a>
         {{ /links }}
-
         {{# Let's users reset their cookies consent when using the cookie banner. #}}
         {{ yield:reset_cookie_consent }}
     </nav>

--- a/export/resources/views/partials/nav-header-desktop.antlers.html
+++ b/export/resources/views/partials/nav-header-desktop.antlers.html
@@ -33,13 +33,13 @@
                     x-transition:leave-start="translate-y-0 opacity-100"
                     x-transition:leave-end="translate-y-1 opacity-0"
                     @click.outside="subnavOpen = false"
-                    class="absolute z-10 mt-5 w-screen transform {{ ['left-1/2 flex max-w-max -translate-x-1/2 px-4' => two_col_menu, 'left-1/2 max-w-xs -translate-x-1/2 px-2' => !two_col_menu] | classes }}"
+                    class="{{ ['left-1/2 flex max-w-max -translate-x-1/2 px-4' => two_col_menu, 'left-1/2 max-w-xs -translate-x-1/2 px-2' => !two_col_menu] | classes }} absolute z-10 mt-5 w-screen transform"
                 >
                     <div
                         class="flex-auto overflow-hidden rounded-lg border bg-white text-sm/6 shadow lg:max-w-3xl"
                     >
                         <div
-                            class="relative grid grid-cols-1 gap-x-5 gap-y-1 p-3 {{ two_col_menu ?= 'lg:grid-cols-2' }}"
+                            class="{{ two_col_menu ?= 'lg:grid-cols-2' }} relative grid grid-cols-1 gap-x-5 gap-y-1 p-3"
                         >
                             {{ children scope="child" }}
                                 <s:partial:partials.nav-header-item

--- a/export/resources/views/partials/nav-header-item.antlers.html
+++ b/export/resources/views/partials/nav-header-item.antlers.html
@@ -9,13 +9,11 @@
             class="text-muted-foreground group-hover:text-primary size-6 transition-colors lg:mt-1"
         />
     {{ /if }}
-
     <div>
         <span class="text-foreground font-medium">{{ title }}</span>
         {{ if badge }}
             <span class="badge badge--outline relative -top-px ml-1.5">{{ badge }}</span>
         {{ /if }}
-
         {{ if description }}
             <p class="text-muted-foreground hidden text-pretty lg:block">{{ description }}</p>
         {{ /if }}

--- a/export/resources/views/partials/nav-header-mob.antlers.html
+++ b/export/resources/views/partials/nav-header-mob.antlers.html
@@ -5,7 +5,14 @@
     as="items"
 >
     {{# Mobile menu #}}
-    <div x-cloak x-show="mobileNavOpen" x-trap.noscroll="mobileNavOpen" class="lg:hidden" role="dialog" aria-modal="true">
+    <div
+        x-cloak
+        x-show="mobileNavOpen"
+        x-trap.noscroll="mobileNavOpen"
+        class="lg:hidden"
+        role="dialog"
+        aria-modal="true"
+    >
         {{# Background backdrop #}}
         <div x-cloak x-show="mobileNavOpen" class="fixed inset-0 z-10"></div>
         <div

--- a/export/resources/views/partials/seo.antlers.html
+++ b/export/resources/views/partials/seo.antlers.html
@@ -1,8 +1,8 @@
 {{ if response_code == 200 }}
     {{# Page title #}}
     <title>
-        {{ yield:seo_title }}
-        {{ seo_title ? seo_title : title }} {{ seo:title_separator }} {{ seo:site_name ? seo:site_name : config:app:name }}
+        {{ yield:seo_title }} {{ seo_title ? seo_title : title }}
+        {{ seo:title_separator }} {{ seo:site_name ? seo:site_name : config:app:name }}
     </title>
 
     {{# Page description #}}
@@ -11,13 +11,8 @@
     {{ elseif seo:collection_defaults }}
         <meta name="description" content="{{ partial:partials/fallback-description }}" />
     {{ /if }}
-
     {{# No index and no follow #}}
-    {{ if
-        (environment == 'local' && !seo:noindex_local) ||
-        (environment == 'staging' && !seo:noindex_staging) ||
-        (environment == 'production' && !seo:noindex_production)
-    }}
+    {{ if (environment == 'local' && !seo:noindex_local) || (environment == 'staging' && !seo:noindex_staging) || (environment == 'production' && !seo:noindex_production) }}
         {{ if seo_noindex && seo_nofollow }}
             <meta name="robots" content="noindex, nofollow" />
         {{ elseif seo_nofollow }}
@@ -28,10 +23,10 @@
     {{ else }}
         <meta name="robots" content="noindex, nofollow" />
     {{ /if }}
-
     {{# hreflang tags #}}
     {{ if seo:hreflang_auto }}
-        {{ if !seo_noindex && seo_canonical_type == 'entry' && current_full_url == permalink }}
+        {{ if !seo_noindex && seo_canonical_type == 'entry'
+ && current_full_url == permalink }}
             <s:locales all="false">
                 <link
                     rel="alternate"
@@ -41,21 +36,21 @@
             </s:locales>
         {{ /if }}
     {{ /if }}
-
     {{# Canonical URL #}}
     {{ unless seo_noindex }}
         {{ if seo_canonical_type == 'entry' }}
             <link rel="canonical" href="{{ permalink }}" />
         {{ elseif seo_canonical_type == 'domain' }}
-            <link rel="canonical" href="{{ config:app:url | trim('/') }}{{ seo_canonical_domain:url }}" />
+            <link
+                rel="canonical"
+                href="{{ config:app:url | trim('/') }}{{ seo_canonical_domain:url }}"
+            />
         {{ elseif seo_canonical_type == 'external' }}
             <link rel="canonical" href="{{ seo_canonical_external }}" />
         {{ /if }}
     {{ /unless }}
-
     {{# Auto add pagination links when using components/ui/pagination/pagination.antlers.html. #}}
     {{ yield:pagination }}
-
     {{# Knowledge graph JSON-ld #}}
     {{ if seo:json_ld_type && seo:json_ld_type != 'none' }}
         {{ if seo:json_ld_type == 'organization' }}
@@ -83,14 +78,11 @@
             <script type="application/ld+json" id="schema">{{ seo:json_ld }}</script>
         {{ /if }}
     {{ /if }}
-
     {{ if schema_jsonld }}
         <script type="application/ld+json" id="schema-page">{{ schema_jsonld }}</script>
     {{ /if }}
-
     {{# Add JSON-LD coming from other places like FAQs #}}
     {{ yield:json_ld }}
-
     {{# Breadcrumbs JSON-ld #}}
     {{ if seo:breadcrumbs && segment_1 }}
         <script type="application/ld+json" id="schema-breadcrumbs">
@@ -110,55 +102,82 @@
             }
         </script>
     {{ /if }}
-
     {{# Open Graph #}}
-    <meta property="og:site_name" content="{{ seo:site_name ? seo:site_name : config:app:name }}" />
+    <meta
+        property="og:site_name"
+        content="{{ seo:site_name ? seo:site_name : config:app:name }}"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="{{ site:locale }}" />
-    <meta property="og:title" content="{{ og_title ? og_title : (seo_title ? seo_title : title) }}" />
+    <meta
+        property="og:title"
+        content="{{ og_title ? og_title : (seo_title ? seo_title : title) }}"
+    />
     {{ if og_description || seo_description }}
-        <meta property="og:description" content="{{ og_description ? og_description : seo_description }}" />
+        <meta
+            property="og:description"
+            content="{{ og_description ? og_description : seo_description }}"
+        />
     {{ elseif seo:collection_defaults }}
         <meta property="og:description" content="{{ partial:partials/fallback-description }}" />
     {{ /if }}
     {{ if og_image }}
-        <meta property="og:image" content="{{ glide:og_image width='1200' height='630' fit='crop_focal' absolute='true' }}" />
+        <meta
+            property="og:image"
+            content="{{ glide:og_image width='1200' height='630' fit='crop_focal' absolute='true' }}"
+        />
     {{ elseif seo:og_image }}
-        <meta property="og:image" content="{{ glide:seo:og_image width='1200' height='630' fit='crop_focal' absolute='true' }}" />
+        <meta
+            property="og:image"
+            content="{{ glide:seo:og_image width='1200' height='630' fit='crop_focal' absolute='true' }}"
+        />
     {{ /if }}
-
     {{# Twitter #}}
     {{ if twitter_image || seo:twitter_image }}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="{{ seo:twitter_handle | ensure_left('@') }}" />
-        <meta name="twitter:title" content="{{ og_title ? og_title : (seo_title ? seo_title : title) }}" />
+        <meta
+            name="twitter:title"
+            content="{{ og_title ? og_title : (seo_title ? seo_title : title) }}"
+        />
         {{ if og_description || seo_description }}
-            <meta name="twitter:description" content="{{ og_description ? og_description : seo_description }}" />
+            <meta
+                name="twitter:description"
+                content="{{ og_description ? og_description : seo_description }}"
+            />
         {{ elseif seo:collection_defaults }}
-            <meta name="twitter:description" content="{{ partial:partials/fallback-description }}" />
+            <meta
+                name="twitter:description"
+                content="{{ partial:partials/fallback-description }}"
+            />
         {{ /if }}
         {{ if twitter_image }}
-            <meta name="twitter:image" content="{{ glide:twitter_image width='1200' height='600' fit='crop_focal' absolute='true' }}" />
+            <meta
+                name="twitter:image"
+                content="{{ glide:twitter_image width='1200' height='600' fit='crop_focal' absolute='true' }}"
+            />
             {{ asset url="{twitter_image}" }}
-                {{ if alt }}<meta name="twitter:image:alt" content="{{ alt }}" />{{ /if }}
+                {{ if alt }}
+                    <meta name="twitter:image:alt" content="{{ alt }}" />
+                {{ /if }}
             {{ /asset }}
         {{ elseif seo:twitter_image }}
-            <meta name="twitter:image" content="{{ glide:seo:twitter_image width='1200' height='600' fit='crop_focal' absolute='true' }}" />
+            <meta
+                name="twitter:image"
+                content="{{ glide:seo:twitter_image width='1200' height='600' fit='crop_focal' absolute='true' }}"
+            />
             {{ asset url="{seo:twitter_image}" }}
-                {{ if alt }}<meta name="twitter:image:alt" content="{{ alt }}" />{{ /if }}
+                {{ if alt }}
+                    <meta name="twitter:image:alt" content="{{ alt }}" />
+                {{ /if }}
             {{ /asset }}
         {{ /if }}
     {{ /if }}
 {{ else }}
     <title>{{ response_code }} | {{ config:app:name }}</title>
 {{ /if }}
-
 {{# Trackers #}}
-{{ if
-    (environment == 'local' && seo:trackers_local) ||
-    (environment == 'staging' && seo:trackers_staging) ||
-    (environment == 'production' && seo:trackers_production)
-}}
+{{ if (environment == 'local' && seo:trackers_local) || (environment == 'staging' && seo:trackers_staging) || (environment == 'production' && seo:trackers_production) }}
     {{ if seo:tracker_type == 'gtm' }}
         <script>
             ;(function (w, d, s, l, i) {
@@ -192,27 +211,30 @@
             })
         </script>
     {{ /if }}
-
     {{# Yield this section in all your layouts after opening the <body> #}}
     {{ section:seo_body }}
         {{ if seo:tracker_type == 'gtm' }}
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ seo:google_tag_manager }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+            <noscript>
+                <iframe
+                    src="https://www.googletagmanager.com/ns.html?id={{ seo:google_tag_manager }}"
+                    height="0"
+                    width="0"
+                    style="display: none; visibility: hidden"
+                ></iframe>
+            </noscript>
         {{ /if }}
         {{ if seo:use_cookie_dialog }}
             <s:partial:partials.cookie-dialog />
         {{ /if }}
     {{ /section:seo_body }}
-
     {{ if seo:use_google_site_verification }}
         <meta name="google-site-verification" content="{{ seo:google_site_verification }}" />
     {{ /if }}
-
     {{ if seo:use_fathom && seo:fathom_use_custom_domain }}
         <script src="{{ seo:fathom_custom_script_url }}" site="{{ seo:fathom }}" defer></script>
     {{ elseif seo:use_fathom }}
         <script src="https://cdn.usefathom.com/script.js" site="{{ seo:fathom }}" defer></script>
     {{ /if }}
-
     {{ if seo:use_cloudflare_web_analytics }}
         <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "{{ seo:cloudflare_web_analytics }}"}'></script>
     {{ /if }}

--- a/export/resources/views/partials/social-sharing.antlers.html
+++ b/export/resources/views/partials/social-sharing.antlers.html
@@ -3,7 +3,7 @@ class: ''
 ---
 
 <ul
-    class="flex items-center gap-4 {{ view:class }}"
+    class="{{ view:class }} flex items-center gap-4"
     x-data="{
         popupWindow: (url, windowName, win, w, h) => {
             const y = win.top.outerHeight / 2 + win.top.screenY - h / 2

--- a/export/resources/views/partials/style-guide/button-row.antlers.html
+++ b/export/resources/views/partials/style-guide/button-row.antlers.html
@@ -7,9 +7,32 @@ variant: 'primary'
         btn--{{ view:variant }}
     </dt>
     <dd class="flex flex-col items-start justify-start gap-6 md:flex-row md:items-end">
-        <s:partial:components.ui.button :variant="view:variant" label="Get started" link_type="url" url="/" size="sm" />
-        <s:partial:components.ui.button :variant="view:variant" label="Get started" link_type="url" url="/" />
-        <s:partial:components.ui.button :variant="view:variant" label="Get started" link_type="url" url="/" size="lg" />
-        <s:partial:components.ui.button :variant="view:variant" label="Get started" link_type="url" url="/" size="xl" />
+        <s:partial:components.ui.button
+            :variant="view:variant"
+            label="Get started"
+            link_type="url"
+            url="/"
+            size="sm"
+        />
+        <s:partial:components.ui.button
+            :variant="view:variant"
+            label="Get started"
+            link_type="url"
+            url="/"
+        />
+        <s:partial:components.ui.button
+            :variant="view:variant"
+            label="Get started"
+            link_type="url"
+            url="/"
+            size="lg"
+        />
+        <s:partial:components.ui.button
+            :variant="view:variant"
+            label="Get started"
+            link_type="url"
+            url="/"
+            size="xl"
+        />
     </dd>
 </div>

--- a/export/resources/views/partials/style-guide/content-row.antlers.html
+++ b/export/resources/views/partials/style-guide/content-row.antlers.html
@@ -3,6 +3,8 @@ size: 'content'
 ---
 
 <div class="flex items-center">
-    <dt class="content-sm text-muted-foreground w-32 shrink-0 font-mono leading-6">{{ view:size }}</dt>
+    <dt class="content-sm text-muted-foreground w-32 shrink-0 font-mono leading-6">
+        {{ view:size }}
+    </dt>
     <dd class="{{ view:size }} truncate">The quick brown fox jumps over the lazy dog.</dd>
 </div>

--- a/export/resources/views/partials/style-guide/heading-row.antlers.html
+++ b/export/resources/views/partials/style-guide/heading-row.antlers.html
@@ -3,6 +3,10 @@ heading: 'h1'
 ---
 
 <div class="flex items-center">
-    <dt class="content-sm text-muted-foreground w-16 shrink-0 font-mono leading-6">{{ view:heading }}</dt>
-    <dd class="{{ view:heading }} truncate leading-tight">The quick brown fox jumps over the lazy dog.</dd>
+    <dt class="content-sm text-muted-foreground w-16 shrink-0 font-mono leading-6">
+        {{ view:heading }}
+    </dt>
+    <dd class="{{ view:heading }} truncate leading-tight">
+        The quick brown fox jumps over the lazy dog.
+    </dd>
 </div>

--- a/export/resources/views/posts/show.antlers.html
+++ b/export/resources/views/posts/show.antlers.html
@@ -12,13 +12,16 @@
                 />
             </div>
             <h1 class="h1 mt-em">{{ title }}</h1>
-            <s:partial:components.entry-meta :date="date" :category="categories:title" class="mt-6" />
+            <s:partial:components.entry-meta
+                :date="date"
+                :category="categories:title"
+                class="mt-6"
+            />
             <s:partial:partials.social-sharing class="mt-6" />
         </div>
     </div>
 
     <s:partial:blocks.article />
-
     {{ if show_related_posts }}
         <s:partial:partials.related-posts />
     {{ /if }}

--- a/export/resources/views/sets/faqs.antlers.html
+++ b/export/resources/views/sets/faqs.antlers.html
@@ -1,5 +1,8 @@
 <div class="not-prose">
-    <s:partial:components.faqs :items="items" class="divide-y divide-gray-300 border-b border-gray-300">
+    <s:partial:components.faqs
+        :items="items"
+        class="divide-y divide-gray-300 border-b border-gray-300"
+    >
         {{ items }}
             <s:partial:components.faqs-item :title="title" :text="text" />
         {{ /items }}

--- a/export/resources/views/sets/picture.antlers.html
+++ b/export/resources/views/sets/picture.antlers.html
@@ -1,6 +1,5 @@
 <figure class="not-prose my-0">
     <s:partial:components.ui.picture :image="image" w="800" h="auto" />
-
     {{ if caption }}
         <figcaption class="mt-2 block text-sm">{{ caption }}</figcaption>
     {{ /if }}

--- a/export/resources/views/sets/video.antlers.html
+++ b/export/resources/views/sets/video.antlers.html
@@ -4,7 +4,6 @@
         <s:vite src="resources/js/lite-yt-embed.js" />
     {{ /push:scripts }}
 {{ /once }}
-
 <figure class="not-prose my-0">
     <lite-youtube
         videoid="{{ youtube_id }}"
@@ -15,7 +14,6 @@
             <span class="lyt-visually-hidden">Play Video</span>
         </a>
     </lite-youtube>
-
     {{ if caption }}
         <figcaption class="text-muted-foreground mt-2 block text-sm">{{ caption }}</figcaption>
     {{ /if }}

--- a/export/routes/web.php
+++ b/export/routes/web.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\NewsletterController;
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Support\Facades\Route;
 
 // Route for handling newsletter subscriptions.
 Route::post('/newsletter', NewsletterController::class)

--- a/export/tests/Feature/Console/ClearDemoContentCommandTest.php
+++ b/export/tests/Feature/Console/ClearDemoContentCommandTest.php
@@ -1,0 +1,206 @@
+<?php
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\Prompt;
+use Statamic\Entries\Entry;
+use Statamic\Facades\Asset;
+use Statamic\Facades\AssetContainer;
+use Statamic\Facades\Entry as EntryFacade;
+use Statamic\Facades\GlobalSet;
+use Statamic\Facades\GlobalVariables;
+use Statamic\Facades\Nav;
+use Statamic\Facades\Site;
+use Statamic\Facades\Term;
+
+beforeAll(function () {
+    // Auto-confirm prompts for destructive actions.
+    Prompt::fallbackWhen(true);
+    ConfirmPrompt::fallbackUsing(fn () => true);
+});
+
+beforeEach(function () {
+    // Backup the entire content directory so we can restore it after the test.
+    $this->fs = new Filesystem;
+    $this->contentPath = base_path('content');
+    $this->backupPath = base_path('content_backup_for_tests');
+
+    if ($this->fs->exists($this->backupPath)) {
+        $this->fs->deleteDirectory($this->backupPath);
+    }
+    $this->fs->copyDirectory($this->contentPath, $this->backupPath);
+
+    // Backup the assets directory so we can restore it after the test.
+    $this->assetsPath = public_path('assets');
+    $this->assetsBackupPath = public_path('assets_backup_for_tests');
+
+    if ($this->fs->exists($this->assetsBackupPath)) {
+        $this->fs->deleteDirectory($this->assetsBackupPath);
+    }
+    if ($this->fs->exists($this->assetsPath)) {
+        $this->fs->copyDirectory($this->assetsPath, $this->assetsBackupPath);
+    }
+});
+
+afterEach(function () {
+    // Restore content directory from backup
+    if (isset($this->fs) && $this->fs->exists($this->backupPath)) {
+        $this->fs->deleteDirectory($this->contentPath);
+        $this->fs->copyDirectory($this->backupPath, $this->contentPath);
+        $this->fs->deleteDirectory($this->backupPath);
+    }
+
+    // Restore assets directory from backup
+    if (isset($this->fs) && $this->fs->exists($this->assetsBackupPath)) {
+        if ($this->fs->exists($this->assetsPath)) {
+            $this->fs->deleteDirectory($this->assetsPath);
+        }
+        $this->fs->copyDirectory($this->assetsBackupPath, $this->assetsPath);
+        $this->fs->deleteDirectory($this->assetsBackupPath);
+    }
+});
+
+test('bedrock:clear removes demo content while preserving home entry', function () {
+    // Ensure home exists; if not, create it.
+    $home = EntryFacade::whereCollection('pages')->first(fn ($entry) => $entry->slug() === 'home');
+    if (! $home) {
+        /** @var Entry $newHome */
+        $newHome = EntryFacade::make();
+        $newHome
+            ->collection('pages')
+            ->slug('home')
+            ->data(['title' => 'Home']);
+        $newHome->save();
+        $home = EntryFacade::find($newHome->id());
+    }
+
+    // Ensure there's at least one other entry to delete
+    if (EntryFacade::all()->count() <= 1) {
+        /** @var Entry $tempPost */
+        $tempPost = EntryFacade::make();
+        $tempPost
+            ->collection('posts')
+            ->slug('temp-post')
+            ->data(['title' => 'Temp Post']);
+        $tempPost->save();
+    }
+
+    // Ensure at least one term exists in categories
+    if (Term::whereTaxonomy('categories')->count() === 0) {
+        /** @var Statamic\Taxonomies\Term $tempTerm */
+        $tempTerm = Term::make('temp-category');
+        $tempTerm->taxonomy('categories')->set('title', 'Temp Category');
+        $tempTerm->save();
+    }
+
+    // Ensure globals exist for specified sets across default site
+    foreach (['banner', 'browser_appearance', 'newsletter', 'social_media', 'theme'] as $handle) {
+        if (GlobalVariables::whereSet($handle)->count() === 0) {
+            $vars = GlobalSet::findByHandle($handle)?->inDefaultSite();
+            if ($vars) {
+                $vars->set('seeded', true)->save();
+            }
+        }
+    }
+
+    // Ensure at least one nav has items in at least one site
+    $sites = Site::all()->map->handle();
+    foreach (Nav::all() as $nav) {
+        foreach ($sites as $site) {
+            $tree = $nav->in($site);
+            if ($tree && empty($tree->tree())) {
+                $tree->tree([['entry' => $home->id()]])->save();
+            }
+        }
+    }
+
+    // Create test assets by copying existing files and creating new Statamic asset entries
+    $fs = new Filesystem;
+    $container = AssetContainer::findByHandle('assets');
+    $assetsPath = public_path('assets');
+
+    // Create simple test files in the filesystem first
+    $fs->ensureDirectoryExists($assetsPath.'/images');
+    $fs->ensureDirectoryExists($assetsPath.'/avatars');
+    $fs->ensureDirectoryExists($assetsPath.'/logos');
+
+    $fs->put($assetsPath.'/images/test-demo-image.txt', 'test image content');
+    $fs->put($assetsPath.'/avatars/test-demo-avatar.txt', 'test avatar content');
+    $fs->put($assetsPath.'/logos/test-demo-logo.txt', 'test logo content');
+
+    // Create Statamic asset entries for these files
+    $testImageAsset = Asset::make()
+        ->container($container->handle())
+        ->path('images/test-demo-image.txt')
+        ->syncOriginal();
+    $testImageAsset->save();
+
+    $testAvatarAsset = Asset::make()
+        ->container($container->handle())
+        ->path('avatars/test-demo-avatar.txt')
+        ->syncOriginal();
+    $testAvatarAsset->save();
+
+    $testLogoAsset = Asset::make()
+        ->container($container->handle())
+        ->path('logos/test-demo-logo.txt')
+        ->syncOriginal();
+    $testLogoAsset->save();
+
+    // Store references for assertions later
+    $this->testImageAssetId = $testImageAsset->id();
+    $this->testAvatarAssetId = $testAvatarAsset->id();
+    $this->testLogoAssetId = $testLogoAsset->id();
+
+    // Run the command
+    $this->artisan('bedrock:clear', ['--force' => true])->assertExitCode(Command::SUCCESS);
+
+    // 1) Entries: only home page should remain in pages; other collections should be empty
+    $entries = EntryFacade::all();
+    // Keep everything that is the home entry
+    $nonHome = $entries->reject(fn ($entry) => $entry->id() === $home->id());
+    expect($nonHome->count())->toBe(0);
+
+    // Home must have fields cleared
+    /** @var Entry $freshHome */
+    $freshHome = EntryFacade::find($home->id());
+    expect($freshHome->data()->get('blocks'))->toBeNull();
+    expect($freshHome->data()->get('seo_title'))->toBeNull();
+    expect($freshHome->data()->get('seo_description'))->toBeNull();
+    expect($freshHome->data()->get('og_image'))->toBeNull();
+    expect($freshHome->data()->get('twitter_image'))->toBeNull();
+
+    // 2) Navs: all trees should be empty
+    foreach (Nav::all() as $nav) {
+        foreach (Site::all()->map->handle() as $site) {
+            $tree = $nav->in($site);
+            if ($tree) {
+                expect($tree->tree())->toBe([]);
+            }
+        }
+    }
+
+    // 3) Terms: categories should be empty
+    expect(Term::whereTaxonomy('categories')->count())->toBe(0);
+
+    // 4) Globals: variables for selected sets should be deleted
+    foreach (['banner', 'browser_appearance', 'newsletter', 'social_media', 'theme'] as $handle) {
+        expect(GlobalVariables::whereSet($handle)->count())->toBe(0);
+    }
+
+    // 5) Assets: demo assets should be deleted, but logos should be preserved
+    expect(Asset::find($this->testImageAssetId))->toBeNull();
+    expect(Asset::find($this->testAvatarAssetId))->toBeNull();
+
+    // Logo asset should still exist
+    expect(Asset::find($this->testLogoAssetId))->not->toBeNull();
+
+    // Verify by folder: logos folder should still have assets, others should be empty
+    $remainingLogoAssets = Asset::whereFolder('logos', 'assets');
+    expect($remainingLogoAssets->count())->toBeGreaterThan(0);
+
+    // .gitkeep should be preserved
+    $fs = new Filesystem;
+    expect($fs->exists(public_path('assets/.gitkeep')))->toBeTrue();
+});

--- a/export/tests/Feature/Console/RenameBlockCommandTest.php
+++ b/export/tests/Feature/Console/RenameBlockCommandTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use App\Support\Yaml\BlocksYaml;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\Prompt;
+use Statamic\Facades\Config as StatamicConfig;
+use Statamic\Facades\Entry;
+use Statamic\Facades\YAML;
+
+beforeAll(function () {
+    // Always auto-confirm prompts in tests, except for optional group move.
+    Prompt::fallbackWhen(true);
+    ConfirmPrompt::fallbackUsing(function ($prompt = null) {
+        $label = method_exists($prompt, 'label') ? (string) $prompt->label() : '';
+        // Say "no" to optional group move to avoid extra select prompts.
+        if (str_contains(strtolower($label), 'move this block to a different group')) {
+            return false;
+        }
+
+        // Default to yes for other confirmations (e.g. rename confirmation).
+        return true;
+    });
+});
+
+beforeEach(function () {
+    setUpBedrockScaffoldPaths();
+});
+
+afterEach(function () {
+    tearDownBedrockScaffoldPaths();
+
+    $worker = bedrockTestWorkerToken();
+    foreach (glob(base_path("content/collections/pages/test-page-w{$worker}-*.md")) ?: [] as $file) {
+        @unlink($file);
+    }
+});
+
+test('rename:bedrock-block renames files and updates blocks.yaml', function () {
+    $group = 'messaging';
+    $originalName = 'Scaffold Test Block '.Str::random(6);
+    $newName = 'Scaffold Renamed Block '.Str::random(6);
+
+    $locale = StatamicConfig::getShortLocale();
+    $originalFieldset = Str::slug($originalName, '_', $locale);
+    $originalView = Str::slug($originalName, '-', $locale);
+    $newFieldset = Str::slug($newName, '_', $locale);
+    $newView = Str::slug($newName, '-', $locale);
+
+    // First create a block
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $originalName,
+        '--instructions' => 'Test instructions',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    $originalFieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$originalFieldset}.yaml";
+    $originalViewPath = config('statamic.bedrock.scaffold.blocks_views_path')."/{$originalView}.antlers.html";
+    $newFieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$newFieldset}.yaml";
+    $newViewPath = config('statamic.bedrock.scaffold.blocks_views_path')."/{$newView}.antlers.html";
+
+    // Verify original files exist
+    expect(is_file($originalFieldsetPath))->toBeTrue();
+    expect(is_file($originalViewPath))->toBeTrue();
+
+    // Now rename the block
+    $this->artisan('rename:bedrock-block', [
+        'group' => $group,
+        'current_name' => $originalFieldset,
+        'new_name' => $newName,
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Verify old files are gone and new files exist
+    expect(is_file($originalFieldsetPath))->toBeFalse();
+    expect(is_file($originalViewPath))->toBeFalse();
+    expect(is_file($newFieldsetPath))->toBeTrue();
+    expect(is_file($newViewPath))->toBeTrue();
+
+    // Verify blocks.yaml is updated using BlocksYaml class
+    $blocks = app(BlocksYaml::class);
+    $sets = $blocks->sets($group);
+
+    expect(isset($sets[$originalFieldset]))->toBeFalse();
+    expect(isset($sets[$newFieldset]))->toBeTrue();
+    expect($sets[$newFieldset])->toBe($newName);
+
+    // Fieldset title should be updated
+    $data = YAML::file($newFieldsetPath)->parse() ?? [];
+    expect($data['title'] ?? null)->toBe($newName);
+});
+
+test('rename:bedrock-block updates content entries', function () {
+    $group = 'messaging';
+    $originalName = 'Scaffold Test Block '.Str::random(6);
+    $newName = 'Scaffold Renamed Block '.Str::random(6);
+
+    $locale = StatamicConfig::getShortLocale();
+    $originalFieldset = Str::slug($originalName, '_', $locale);
+    $newFieldset = Str::slug($newName, '_', $locale);
+
+    // First create a block
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $originalName,
+        '--instructions' => 'Test instructions',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Create a page entry that uses the block
+    /** @var Statamic\Entries\Entry $entry */
+    $entry = Entry::make();
+    $entry->collection('pages');
+    $entry->id($entryId = bedrockTestEntryId('test-page'));
+    $entry->slug($entryId);
+    $entry->data([
+        'title' => 'Test Page',
+        'blocks' => [['type' => $originalFieldset, 'enabled' => true]],
+    ]);
+    $entry->save();
+
+    // Now rename the block
+    $this->artisan('rename:bedrock-block', [
+        'group' => $group,
+        'current_name' => $originalFieldset,
+        'new_name' => $newName,
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Verify entry is updated with new block type
+    /** @var Statamic\Entries\Entry|null $updated */
+    $updated = Entry::find($entryId);
+    expect($updated)->not->toBeNull();
+
+    $blocks = (array) $updated->data()->get('blocks');
+    $hasOldBlock = collect($blocks)->contains(
+        fn ($i) => is_array($i) && ($i['type'] ?? null) === $originalFieldset
+    );
+    $hasNewBlock = collect($blocks)->contains(
+        fn ($i) => is_array($i) && ($i['type'] ?? null) === $newFieldset
+    );
+
+    expect($hasOldBlock)->toBeFalse();
+    expect($hasNewBlock)->toBeTrue();
+});
+
+test('rename:bedrock-block fails when target files exist without --force', function () {
+    $group = 'messaging';
+    $originalName = 'Scaffold Test Block '.Str::random(6);
+    $newName = 'Scaffold Renamed Block '.Str::random(6);
+
+    $locale = StatamicConfig::getShortLocale();
+    $originalFieldset = Str::slug($originalName, '_', $locale);
+    $newFieldset = Str::slug($newName, '_', $locale);
+
+    // Create original block
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $originalName,
+        '--instructions' => 'Test instructions',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Create another block with the target name
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $newName,
+        '--instructions' => 'Test instructions',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Rename should fail without --force
+    $this->artisan('rename:bedrock-block', [
+        'group' => $group,
+        'current_name' => $originalFieldset,
+        'new_name' => $newName,
+    ])->assertExitCode(Command::FAILURE);
+});
+
+test('rename:bedrock-block fails when source block does not exist', function () {
+    $this->artisan('rename:bedrock-block', [
+        'group' => 'messaging',
+        'current_name' => 'nonexistent_block',
+        'new_name' => 'New Name',
+    ])->assertExitCode(Command::FAILURE);
+});

--- a/export/tests/Feature/Console/RenameSetCommandTest.php
+++ b/export/tests/Feature/Console/RenameSetCommandTest.php
@@ -1,0 +1,206 @@
+<?php
+
+use App\Support\Yaml\ArticleYaml;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\Prompt;
+use Statamic\Facades\Config as StatamicConfig;
+use Statamic\Facades\Entry;
+use Statamic\Facades\YAML;
+
+beforeAll(function () {
+    // Always auto-confirm prompts in tests, except for optional group move.
+    Prompt::fallbackWhen(true);
+    ConfirmPrompt::fallbackUsing(function ($prompt = null) {
+        $label = method_exists($prompt, 'label') ? (string) $prompt->label() : '';
+        // Say "no" to optional group move to avoid extra select prompts.
+        if (str_contains(strtolower($label), 'move this set to a different group')) {
+            return false;
+        }
+
+        // Default to yes for other confirmations (e.g. rename confirmation).
+        return true;
+    });
+});
+
+beforeEach(function () {
+    setUpBedrockScaffoldPaths();
+});
+
+afterEach(function () {
+    tearDownBedrockScaffoldPaths();
+
+    $worker = bedrockTestWorkerToken();
+    foreach (glob(base_path("content/collections/posts/test-post-w{$worker}-*.md")) ?: [] as $file) {
+        @unlink($file);
+    }
+});
+
+test('rename:bedrock-set renames files and updates article.yaml', function () {
+    $group = 'text_layout';
+    $originalName = 'Scaffold Test Set '.Str::random(6);
+    $newName = 'Scaffold Renamed Set '.Str::random(6);
+
+    $locale = StatamicConfig::getShortLocale();
+    $originalFieldset = Str::slug($originalName, '_', $locale);
+    $originalView = Str::slug($originalName, '-', $locale);
+    $newFieldset = Str::slug($newName, '_', $locale);
+    $newView = Str::slug($newName, '-', $locale);
+
+    // First create a set
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $originalName,
+        '--instructions' => 'Test instructions',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    $originalFieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$originalFieldset}.yaml";
+    $originalViewPath = config('statamic.bedrock.scaffold.sets_views_path')."/{$originalView}.antlers.html";
+    $newFieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$newFieldset}.yaml";
+    $newViewPath = config('statamic.bedrock.scaffold.sets_views_path')."/{$newView}.antlers.html";
+
+    // Verify original files exist
+    expect(is_file($originalFieldsetPath))->toBeTrue();
+    expect(is_file($originalViewPath))->toBeTrue();
+
+    // Now rename the set
+    $this->artisan('rename:bedrock-set', [
+        'group' => $group,
+        'current_name' => $originalFieldset,
+        'new_name' => $newName,
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Verify old files are gone and new files exist
+    expect(is_file($originalFieldsetPath))->toBeFalse();
+    expect(is_file($originalViewPath))->toBeFalse();
+    expect(is_file($newFieldsetPath))->toBeTrue();
+    expect(is_file($newViewPath))->toBeTrue();
+
+    // Verify article.yaml is updated using ArticleYaml class
+    $article = app(ArticleYaml::class);
+    $sets = $article->sets($group);
+
+    expect(isset($sets[$originalFieldset]))->toBeFalse();
+    expect(isset($sets[$newFieldset]))->toBeTrue();
+    expect($sets[$newFieldset])->toBe($newName);
+
+    // Fieldset title should be updated
+    $data = YAML::file($newFieldsetPath)->parse() ?? [];
+    expect($data['title'] ?? null)->toBe($newName);
+});
+
+test('rename:bedrock-set updates content entries', function () {
+    $group = 'text_layout';
+    $originalName = 'Scaffold Test Set '.Str::random(6);
+    $newName = 'Scaffold Renamed Set '.Str::random(6);
+
+    $locale = StatamicConfig::getShortLocale();
+    $originalFieldset = Str::slug($originalName, '_', $locale);
+    $newFieldset = Str::slug($newName, '_', $locale);
+
+    // First create a set
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $originalName,
+        '--instructions' => 'Test instructions',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Create a post entry that uses the set in Bard
+    /** @var Statamic\Entries\Entry $entry */
+    $entry = Entry::make();
+    $entry->collection('posts');
+    $entry->id($entryId = bedrockTestEntryId('test-post'));
+    $entry->slug($entryId);
+    $entry->data([
+        'title' => 'Test Post',
+        'article' => [
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'id' => 'abc',
+                    'values' => [
+                        'type' => $originalFieldset,
+                    ],
+                ],
+            ],
+        ],
+    ]);
+    $entry->save();
+
+    // Now rename the set
+    $this->artisan('rename:bedrock-set', [
+        'group' => $group,
+        'current_name' => $originalFieldset,
+        'new_name' => $newName,
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Verify entry is updated with new set type
+    /** @var Statamic\Entries\Entry|null $updated */
+    $updated = Entry::find($entryId);
+    expect($updated)->not->toBeNull();
+
+    $article = (array) $updated->data()->get('article');
+    $hasOldSet = collect($article)->contains(function ($node) use ($originalFieldset) {
+        if (! is_array($node) || ($node['type'] ?? null) !== 'set') {
+            return false;
+        }
+
+        return ($node['attrs']['values']['type'] ?? null) === $originalFieldset;
+    });
+    $hasNewSet = collect($article)->contains(function ($node) use ($newFieldset) {
+        if (! is_array($node) || ($node['type'] ?? null) !== 'set') {
+            return false;
+        }
+
+        return ($node['attrs']['values']['type'] ?? null) === $newFieldset;
+    });
+
+    expect($hasOldSet)->toBeFalse();
+    expect($hasNewSet)->toBeTrue();
+});
+
+test('rename:bedrock-set fails when target files exist without --force', function () {
+    $group = 'text_layout';
+    $originalName = 'Scaffold Test Set '.Str::random(6);
+    $newName = 'Scaffold Renamed Set '.Str::random(6);
+
+    $locale = StatamicConfig::getShortLocale();
+    $originalFieldset = Str::slug($originalName, '_', $locale);
+    $newFieldset = Str::slug($newName, '_', $locale);
+
+    // Create original set
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $originalName,
+        '--instructions' => 'Test instructions',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Create another set with the target name
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $newName,
+        '--instructions' => 'Test instructions',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Rename should fail without --force
+    $this->artisan('rename:bedrock-set', [
+        'group' => $group,
+        'current_name' => $originalFieldset,
+        'new_name' => $newName,
+    ])->assertExitCode(Command::FAILURE);
+});
+
+test('rename:bedrock-set fails when source set does not exist', function () {
+    $this->artisan('rename:bedrock-set', [
+        'group' => 'text_layout',
+        'current_name' => 'nonexistent_set',
+        'new_name' => 'New Name',
+    ])->assertExitCode(Command::FAILURE);
+});

--- a/export/tests/Feature/Console/ScaffoldCommandsTest.php
+++ b/export/tests/Feature/Console/ScaffoldCommandsTest.php
@@ -1,0 +1,371 @@
+<?php
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\Prompt;
+use Statamic\Facades\Config as StatamicConfig;
+use Statamic\Facades\Entry;
+use Statamic\Facades\YAML;
+
+beforeAll(function () {
+    // Always auto-confirm destructive prompts in tests.
+    Prompt::fallbackWhen(true);
+    ConfirmPrompt::fallbackUsing(fn () => true);
+});
+
+beforeEach(function () {
+    setUpBedrockScaffoldPaths();
+
+    $this->blocksYamlPath = config('statamic.bedrock.scaffold.fieldsets_path').'/blocks.yaml';
+    $this->articleYamlPath = config('statamic.bedrock.scaffold.fieldsets_path').'/article.yaml';
+});
+
+afterEach(function () {
+    tearDownBedrockScaffoldPaths();
+
+    // Entries live in the shared Statamic content tree; clean only this worker's.
+    $worker = bedrockTestWorkerToken();
+    $globPaths = [
+        base_path("content/collections/pages/test-page-w{$worker}-*.md"),
+        base_path("content/collections/posts/test-post-w{$worker}-*.md"),
+    ];
+
+    foreach ($globPaths as $pattern) {
+        foreach (glob($pattern) ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+});
+
+function parseYaml(string $path): array
+{
+    return YAML::file($path)->parse() ?? [];
+}
+
+function findFieldIndexByHandle(array $data, string $handle): int
+{
+    foreach ($data['fields'] ?? [] as $index => $field) {
+        if (($field['handle'] ?? null) === $handle) {
+            return $index;
+        }
+    }
+
+    return -1;
+}
+
+test('make:bedrock-block creates files and updates blocks.yaml', function () {
+    $group = 'messaging';
+    $name = 'Scaffold Test Block '.Str::random(6);
+    $instructions = 'Test instructions';
+
+    $locale = StatamicConfig::getShortLocale();
+    $fieldset = Str::slug($name, '_', $locale);
+    $view = Str::slug($name, '-', $locale);
+
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => $instructions,
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    $fieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$fieldset}.yaml";
+    $viewPath = config('statamic.bedrock.scaffold.blocks_views_path')."/{$view}.antlers.html";
+
+    expect(is_file($fieldsetPath))->toBeTrue();
+    expect(is_file($viewPath))->toBeTrue();
+
+    $data = parseYaml($this->blocksYamlPath);
+    $idx = findFieldIndexByHandle($data, 'blocks');
+    expect($idx)->toBeGreaterThan(-1);
+
+    $config = $data['fields'][$idx]['field']['sets'][$group]['sets'][$fieldset] ?? null;
+    expect($config)->not->toBeNull();
+    expect($config['display'] ?? null)->toBe($name);
+    expect($config['instructions'] ?? null)->toBe($instructions);
+    expect($config['fields'][0]['import'] ?? null)->toBe($fieldset);
+});
+
+test('make:bedrock-set creates files and updates article.yaml', function () {
+    $group = 'text_layout';
+    $name = 'Scaffold Test Set '.Str::random(6);
+    $instructions = 'Test instructions';
+
+    $locale = StatamicConfig::getShortLocale();
+    $fieldset = Str::slug($name, '_', $locale);
+    $view = Str::slug($name, '-', $locale);
+
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => $instructions,
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    $fieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$fieldset}.yaml";
+    $viewPath = config('statamic.bedrock.scaffold.sets_views_path')."/{$view}.antlers.html";
+
+    expect(is_file($fieldsetPath))->toBeTrue();
+    expect(is_file($viewPath))->toBeTrue();
+
+    $data = parseYaml($this->articleYamlPath);
+    $idx = findFieldIndexByHandle($data, 'article');
+    expect($idx)->toBeGreaterThan(-1);
+
+    $config = $data['fields'][$idx]['field']['sets'][$group]['sets'][$fieldset] ?? null;
+    expect($config)->not->toBeNull();
+    expect($config['display'] ?? null)->toBe($name);
+    expect($config['instructions'] ?? null)->toBe($instructions);
+    expect($config['fields'][0]['import'] ?? null)->toBe($fieldset);
+});
+
+test('delete:bedrock-block removes from blocks.yaml and deletes files', function () {
+    $group = 'messaging';
+    $name = 'Scaffold Test Block '.Str::random(6);
+    $locale = StatamicConfig::getShortLocale();
+    $fieldset = Str::slug($name, '_', $locale);
+    $view = Str::slug($name, '-', $locale);
+
+    // Create first
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => 'irrelevant',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Create a page entry that uses the block so we exercise usage removal and message still confirms
+    /** @var Statamic\Entries\Entry $entry */
+    $entry = Entry::make();
+    $entry->collection('pages');
+    $entry->id($entryId = bedrockTestEntryId('test-page'));
+    $entry->slug($entryId);
+    $entry->data([
+        'title' => 'Test Page',
+        'blocks' => [['type' => $fieldset, 'enabled' => true]],
+    ]);
+    $entry->save();
+
+    // Then delete
+    $this->artisan('delete:bedrock-block', [
+        'group' => $group,
+        'block' => $fieldset,
+    ])
+        ->expectsConfirmation("Delete '{$name}' from 'Messaging' group?", 'yes')
+        ->assertExitCode(Command::SUCCESS);
+
+    // Entry usages should be removed
+    /** @var Statamic\Entries\Entry|null $updated */
+    $updated = Entry::find($entryId);
+    expect($updated)->not->toBeNull();
+    $blocks = (array) $updated->data()->get('blocks');
+    $hasBlock = collect($blocks)->contains(
+        fn ($i) => is_array($i) && ($i['type'] ?? null) === $fieldset
+    );
+    expect($hasBlock)->toBeFalse();
+
+    $fieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$fieldset}.yaml";
+    $viewPath = config('statamic.bedrock.scaffold.blocks_views_path')."/{$view}.antlers.html";
+
+    expect(is_file($fieldsetPath))->toBeFalse();
+    expect(is_file($viewPath))->toBeFalse();
+
+    $data = parseYaml($this->blocksYamlPath);
+    $idx = findFieldIndexByHandle($data, 'blocks');
+    expect($idx)->toBeGreaterThan(-1);
+    $exists = isset($data['fields'][$idx]['field']['sets'][$group]['sets'][$fieldset]);
+    expect($exists)->toBeFalse();
+});
+
+test('delete:bedrock-block with --keep-files removes blocks.yaml but keeps files', function () {
+    $group = 'messaging';
+    $name = 'Scaffold Test Block '.Str::random(6);
+    $locale = StatamicConfig::getShortLocale();
+    $fieldset = Str::slug($name, '_', $locale);
+    $view = Str::slug($name, '-', $locale);
+
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => 'irrelevant',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    $fieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$fieldset}.yaml";
+    $viewPath = config('statamic.bedrock.scaffold.blocks_views_path')."/{$view}.antlers.html";
+    expect(is_file($fieldsetPath))->toBeTrue();
+    expect(is_file($viewPath))->toBeTrue();
+
+    $this->artisan('delete:bedrock-block', [
+        'group' => $group,
+        'block' => $fieldset,
+        '--keep-files' => true,
+    ])
+        ->expectsConfirmation("Delete '{$name}' from 'Messaging' group?", 'yes')
+        ->assertExitCode(Command::SUCCESS);
+
+    expect(is_file($fieldsetPath))->toBeTrue();
+    expect(is_file($viewPath))->toBeTrue();
+
+    $data = parseYaml($this->blocksYamlPath);
+    $idx = findFieldIndexByHandle($data, 'blocks');
+    expect($idx)->toBeGreaterThan(-1);
+    $exists = isset($data['fields'][$idx]['field']['sets'][$group]['sets'][$fieldset]);
+    expect($exists)->toBeFalse();
+});
+
+test('delete:bedrock-set removes from article.yaml and deletes files', function () {
+    $group = 'text_layout';
+    $name = 'Scaffold Test Set '.Str::random(6);
+    $locale = StatamicConfig::getShortLocale();
+    $fieldset = Str::slug($name, '_', $locale);
+    $view = Str::slug($name, '-', $locale);
+
+    // Create first
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => 'irrelevant',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Create a post entry that uses the set in Bard so we exercise usage removal
+    /** @var Statamic\Entries\Entry $entry */
+    $entry = Entry::make();
+    $entry->collection('posts');
+    $entry->id($entryId = bedrockTestEntryId('test-post'));
+    $entry->slug($entryId);
+    $entry->data([
+        'title' => 'Test Post',
+        'article' => [
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'id' => 'abc',
+                    'values' => [
+                        'type' => $fieldset,
+                    ],
+                ],
+            ],
+        ],
+    ]);
+    $entry->save();
+
+    // Then delete
+    $this->artisan('delete:bedrock-set', [
+        'group' => $group,
+        'set' => $fieldset,
+    ])
+        ->expectsConfirmation("Delete '{$name}' from 'Text & Layout' group?", 'yes')
+        ->assertExitCode(Command::SUCCESS);
+
+    // Entry usages should be removed
+    /** @var Statamic\Entries\Entry|null $updated */
+    $updated = Entry::find($entryId);
+    expect($updated)->not->toBeNull();
+    $article = (array) $updated->data()->get('article');
+    $hasSet = collect($article)->contains(function ($node) use ($fieldset) {
+        if (! is_array($node) || ($node['type'] ?? null) !== 'set') {
+            return false;
+        }
+
+        return ($node['attrs']['values']['type'] ?? null) === $fieldset;
+    });
+    expect($hasSet)->toBeFalse();
+
+    $fieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$fieldset}.yaml";
+    $viewPath = config('statamic.bedrock.scaffold.sets_views_path')."/{$view}.antlers.html";
+
+    expect(is_file($fieldsetPath))->toBeFalse();
+    expect(is_file($viewPath))->toBeFalse();
+
+    $data = parseYaml($this->articleYamlPath);
+    $idx = findFieldIndexByHandle($data, 'article');
+    expect($idx)->toBeGreaterThan(-1);
+    $exists = isset($data['fields'][$idx]['field']['sets'][$group]['sets'][$fieldset]);
+    expect($exists)->toBeFalse();
+});
+
+test('delete:bedrock-set with --keep-files removes from article.yaml but keeps files', function () {
+    $group = 'text_layout';
+    $name = 'Scaffold Test Set '.Str::random(6);
+    $locale = StatamicConfig::getShortLocale();
+    $fieldset = Str::slug($name, '_', $locale);
+    $view = Str::slug($name, '-', $locale);
+
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => 'irrelevant',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    $fieldsetPath = config('statamic.bedrock.scaffold.fieldsets_path')."/{$fieldset}.yaml";
+    $viewPath = config('statamic.bedrock.scaffold.sets_views_path')."/{$view}.antlers.html";
+    expect(is_file($fieldsetPath))->toBeTrue();
+    expect(is_file($viewPath))->toBeTrue();
+
+    $this->artisan('delete:bedrock-set', [
+        'group' => $group,
+        'set' => $fieldset,
+        '--keep-files' => true,
+    ])
+        ->expectsConfirmation("Delete '{$name}' from 'Text & Layout' group?", 'yes')
+        ->assertExitCode(Command::SUCCESS);
+
+    expect(is_file($fieldsetPath))->toBeTrue();
+    expect(is_file($viewPath))->toBeTrue();
+
+    $data = parseYaml($this->articleYamlPath);
+    $idx = findFieldIndexByHandle($data, 'article');
+    expect($idx)->toBeGreaterThan(-1);
+    $exists = isset($data['fields'][$idx]['field']['sets'][$group]['sets'][$fieldset]);
+    expect($exists)->toBeFalse();
+});
+
+test('make:bedrock-block without --force fails when files already exist', function () {
+    $group = 'messaging';
+    $name = 'Scaffold Test Block '.Str::random(6);
+    $locale = StatamicConfig::getShortLocale();
+    $fieldset = Str::slug($name, '_', $locale);
+    $view = Str::slug($name, '-', $locale);
+
+    // First creation succeeds
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => 'irrelevant',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Second should fail due to existing files
+    $this->artisan('make:bedrock-block', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => 'irrelevant',
+    ])->assertExitCode(Command::FAILURE);
+});
+
+test('make:bedrock-set without --force fails when files already exist', function () {
+    $group = 'text_layout';
+    $name = 'Scaffold Test Set '.Str::random(6);
+    $locale = StatamicConfig::getShortLocale();
+    $fieldset = Str::slug($name, '_', $locale);
+    $view = Str::slug($name, '-', $locale);
+
+    // First creation succeeds
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => 'irrelevant',
+        '--force' => true,
+    ])->assertExitCode(Command::SUCCESS);
+
+    // Second should fail due to existing files
+    $this->artisan('make:bedrock-set', [
+        'group' => $group,
+        'name' => $name,
+        '--instructions' => 'irrelevant',
+    ])->assertExitCode(Command::FAILURE);
+});

--- a/export/tests/Pest.php
+++ b/export/tests/Pest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "pest()" function to bind a different classes or traits.
+|
+*/
+
+pest()->extend(TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/**
+ * Per-worker token used to namespace test artefacts (fieldset YAMLs, view
+ * partials, content entries) so parallel Pest workers don't collide.
+ */
+function bedrockTestWorkerToken(): string
+{
+    return (string) (getenv('TEST_TOKEN') ?: '0');
+}
+
+/**
+ * Worker-scoped scratch directory for scaffold test artefacts.
+ */
+function bedrockTestScratchPath(): string
+{
+    return storage_path('framework/testing/bedrock-'.bedrockTestWorkerToken());
+}
+
+/**
+ * Provision an isolated scaffold workspace (fieldsets + views) and rebind the
+ * statamic.bedrock.scaffold.* config so the commands under test write into it. The real
+ * `blocks.yaml` / `article.yaml` are copied in as seeds so commands have the
+ * usual group structure to operate against.
+ */
+function setUpBedrockScaffoldPaths(): void
+{
+    $scratch = bedrockTestScratchPath();
+    $fieldsets = "{$scratch}/fieldsets";
+    $blocksViews = "{$scratch}/views/blocks";
+    $setsViews = "{$scratch}/views/sets";
+
+    foreach ([$fieldsets, $blocksViews, $setsViews] as $dir) {
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+    }
+
+    copy(resource_path('fieldsets/blocks.yaml'), "{$fieldsets}/blocks.yaml");
+    copy(resource_path('fieldsets/article.yaml'), "{$fieldsets}/article.yaml");
+
+    config([
+        'statamic.bedrock.scaffold.fieldsets_path' => $fieldsets,
+        'statamic.bedrock.scaffold.blocks_views_path' => $blocksViews,
+        'statamic.bedrock.scaffold.sets_views_path' => $setsViews,
+    ]);
+}
+
+function tearDownBedrockScaffoldPaths(): void
+{
+    $scratch = bedrockTestScratchPath();
+    if (is_dir($scratch)) {
+        File::deleteDirectory($scratch);
+    }
+}
+
+/**
+ * Build a worker-unique entry id/slug. Use the returned string for both `->id()`
+ * and `->slug()` on the test entry so Statamic's slug-derived filename is also
+ * worker-scoped, letting the afterEach glob clean up reliably across parallel
+ * runs.
+ */
+function bedrockTestEntryId(string $prefix): string
+{
+    return $prefix.'-w'.bedrockTestWorkerToken().'-'.Str::random(6);
+}

--- a/export/tests/TestCase.php
+++ b/export/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}

--- a/export/tests/Unit/ExampleTest.php
+++ b/export/tests/Unit/ExampleTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('that true is true', function () {
+    expect(true)->toBeTrue();
+});

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -8,6 +8,7 @@ export_paths:
   - app/Support/Yaml
   - config/statamic/git.php
   - config/statamic/search.php
+  - config/statamic/bedrock.php
   - content
   - public/assets
   - public/favicon
@@ -23,12 +24,14 @@ export_paths:
   - .env.example
   - .gitignore
   - package.json
+  - phpstan.neon
   - prettier.config.js
   - CLAUDE.md
   - .claude
   - .ai
   - .github/workflows/ci.yml
   - vite.config.js
+  - tests
 dependencies:
   blade-ui-kit/blade-icons: ^1.8
   mallardduck/blade-lucide-icons: ^1.23
@@ -36,4 +39,6 @@ dependencies_dev:
   cboxdk/statamic-mcp: ^2.5
   larastan/larastan: ^3.9
   laravel/boost: ^2.0
+  pestphp/pest: ^4.0
+  pestphp/pest-plugin-laravel: ^4.0
   phpstan/phpstan: ^2.1


### PR DESCRIPTION
## What's new
- Pest test suite covering the scaffold commands (`make`/`rename`/`delete` block & set) and `ClearDemoContent`, with worker-scoped isolation for parallel runs
- PHPStan (larastan) configuration at level 5
- Composer scripts (`dev`, `pint`, `phpstan`, `format`, `test`) auto-merged on install via `StarterKitPostInstall`
- Configurable scaffold paths via `config('statamic.bedrock.scaffold.*')` with sensible production defaults in `config/statamic/bedrock.php`
- Pest and pest-plugin-laravel added as dev dependencies; `tests`, `phpstan.neon`, and the new config added to export paths

## What's fixed
- Newsletter controller/request and several classes now have explicit return types and tidied imports
- Pint formatting applied across PHP files and Prettier formatting across all Antlers templates