### PR TITLE
SEO error page titles and icon tooling cleanup

### DIFF
--- a/export/.claude/settings.local.json
+++ b/export/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(git check-ignore *)",
       "Bash(git ls-tree *)",
       "Bash(git config *)",
-      "Bash(gh run *)"
+      "Bash(gh run *)",
+      "Bash(git rm *)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/export/.gitignore
+++ b/export/.gitignore
@@ -1,4 +1,6 @@
 /node_modules
+/resources/svg/heroicons
+/resources/svg/lucide
 /public/hot
 /public/storage
 /public/vendor/statamic

--- a/export/package.json
+++ b/export/package.json
@@ -6,6 +6,7 @@
     "build": "vite build",
     "icons:heroicons": "sh scripts/icons-heroicons.sh",
     "icons:lucide": "sh scripts/icons-lucide.sh",
+    "postinstall": "npm run icons:heroicons && npm run icons:lucide",
     "lint": "eslint \"resources/js\" --fix",
     "format": "prettier \"resources/**/*.{js,css,scss,html,antlers.html,blade.php}\" --write",
     "format:check": "prettier \"resources/**/*.{js,css,scss,html,antlers.html,blade.php}\" --check",

--- a/export/resources/views/components/cp-toolbar.antlers.html
+++ b/export/resources/views/components/cp-toolbar.antlers.html
@@ -1,7 +1,6 @@
 {{#
     Show the edit entry button if the user has the permission. i.e. shown only for logged in users with
-    a permission. Wrapped in
-    <s:nocache>so it works with static caching enabled.</s:nocache>
+    a permission. Wrapped in `nocache` tag so it works with static caching enabled.
 #}}
 
 <s:nocache select="collection:handle|environment|edit_url">

--- a/export/resources/views/partials/seo.antlers.html
+++ b/export/resources/views/partials/seo.antlers.html
@@ -1,4 +1,6 @@
-{{ if response_code == 200 }}
+{{ if current_template | starts_with('errors.') }}
+    <title>{{ current_template | remove_left('errors.') }} | {{ config:app:name }}</title>
+{{ else }}
     {{# Page title #}}
     <title>
         {{ yield:seo_title }} {{ seo_title ? seo_title : title }}
@@ -173,8 +175,6 @@
             {{ /asset }}
         {{ /if }}
     {{ /if }}
-{{ else }}
-    <title>{{ response_code }} | {{ config:app:name }}</title>
 {{ /if }}
 {{# Trackers #}}
 {{ if (environment == 'local' && seo:trackers_local) || (environment == 'staging' && seo:trackers_staging) || (environment == 'production' && seo:trackers_production) }}


### PR DESCRIPTION
## What's new
- Error pages now derive their `<title>` from the template name (e.g. `404 | App`) instead of the raw response code
- Restored the `postinstall` hook so heroicons and lucide icons are generated automatically on install
- Generated icon directories (`resources/svg/heroicons`, `resources/svg/lucide`) are now gitignored

## What's fixed
- Clarified the `nocache` wrapping comment in the cp-toolbar component