### PR TITLE
Add Alpine Anchor plugin and ESLint tooling

### DIFF
--- a/export/.claude/settings.local.json
+++ b/export/.claude/settings.local.json
@@ -21,7 +21,9 @@
       "Bash(git ls-tree *)",
       "Bash(git config *)",
       "Bash(gh run *)",
-      "Bash(git rm *)"
+      "Bash(git rm *)",
+      "Bash(npm i *)",
+      "Bash(npm run *)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/export/eslint.config.mjs
+++ b/export/eslint.config.mjs
@@ -1,0 +1,44 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  js.configs.recommended,
+  prettier,
+  {
+    ignores: [
+      'node_modules/**',
+      'vendor/**',
+      'storage/**',
+      'bootstrap/cache/**',
+      'public/**',
+      'resources/dist/**',
+    ],
+  },
+  {
+    files: ['resources/js/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        Alpine: 'readonly',
+        Statamic: 'readonly',
+        appName: 'readonly',
+        gtag: 'readonly',
+      },
+    },
+    rules: {
+      'no-console': 'off',
+      'no-debugger': 'error',
+    },
+  },
+  {
+    files: ['vite.config.*', 'eslint.config.*'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+  },
+]

--- a/export/package.json
+++ b/export/package.json
@@ -15,6 +15,7 @@
     "frontend:ci": "npm run lint:ci && npm run format:ci"
   },
   "devDependencies": {
+    "@alpinejs/anchor": "^3.15.12",
     "@alpinejs/collapse": "^3.15.0",
     "@alpinejs/focus": "^3.15.0",
     "@alpinejs/intersect": "^3.15.0",

--- a/export/package.json
+++ b/export/package.json
@@ -29,6 +29,7 @@
     "concurrently": "^9.2.0",
     "embla-carousel": "^8.6.0",
     "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.6.0",
     "heroicons": "^2.2.0",
     "js-cookie": "^3.0.5",
     "laravel-vite-plugin": "^3.1.0",

--- a/export/resources/js/site.js
+++ b/export/resources/js/site.js
@@ -1,4 +1,5 @@
 import Alpine from 'alpinejs'
+import Anchor from '@alpinejs/anchor'
 import Collapse from '@alpinejs/collapse'
 import Persist from '@alpinejs/persist'
 import Focus from '@alpinejs/focus'
@@ -10,5 +11,5 @@ import Cookies from 'js-cookie'
 window.Cookies = Cookies
 window.Alpine = Alpine
 
-Alpine.plugin([Collapse, Focus, Persist, Intersect, Mask, Form])
+Alpine.plugin([Anchor, Collapse, Focus, Persist, Intersect, Mask, Form])
 Alpine.start()

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -26,6 +26,7 @@ export_paths:
   - package.json
   - phpstan.neon
   - prettier.config.js
+  - eslint.config.mjs
   - CLAUDE.md
   - .claude
   - .ai


### PR DESCRIPTION
## What's new
- Register the `@alpinejs/anchor` plugin in `site.js` for element positioning
- Add a flat ESLint config (`eslint.config.mjs`) with browser/Alpine globals and prettier integration
- Add `globals` dev dependency and export `eslint.config.mjs` via the starter kit
- Allow `npm i`/`npm run` in local Claude settings for linting workflows

## What's fixed
- _None_