### PR TITLE
Add bedrock:remove-seo command

### DIFF
--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -40,6 +40,10 @@ class StarterKitPostInstall
                 'Composer\\Config::disableProcessTimeout',
                 'npx concurrently -c "#c4b5fd,#fb7185,#fdba74" "php artisan queue:listen --tries=1" "php artisan pail --timeout=0" "npm run dev" --names=queue,logs,vite',
             ],
+            'post-update-cmd' => [
+                '@php artisan vendor:publish --tag=laravel-assets --ansi --force',
+                '@php artisan boost:update --ansi',
+            ],
             'pint' => 'pint',
             'pint:ci' => 'pint --test --parallel',
             'phpstan' => 'phpstan analyse --configuration=phpstan.neon --no-progress',

--- a/export/app/Console/Commands/RemoveSeo.php
+++ b/export/app/Console/Commands/RemoveSeo.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Statamic\Entries\Entry;
+use Statamic\Facades\Entry as EntryFacade;
+use Statamic\Facades\Stache;
+use Statamic\Facades\YAML;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\warning;
+
+class RemoveSeo extends Command
+{
+    protected $signature = 'bedrock:remove-seo {--force : Run without confirmation}';
+
+    protected $description = 'Remove the built-in SEO implementation so an SEO addon (e.g. seo-pro) can be installed on a blank slate.';
+
+    /**
+     * The SEO fieldsets imported into collection blueprints.
+     *
+     * @var list<string>
+     */
+    private const SEO_FIELDSETS = [
+        'seo_basic',
+        'seo_advanced',
+        'seo_open_graph',
+        'seo_json-ld_schema',
+        'seo_sitemap',
+    ];
+
+    public function __construct(private readonly Filesystem $files)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! $this->confirmedRemoval()) {
+            info('Aborted.');
+
+            return self::SUCCESS;
+        }
+
+        $this->stripSeoFieldsFromEntries($this->seoFieldHandles());
+        $this->deleteSeoFiles();
+        $this->removeSeoTabFromBlueprints();
+        $this->cleanUpTemplates();
+        $this->removeCookieDialogFromVite();
+        $this->clearStache();
+        $this->printNextSteps();
+
+        info('SEO implementation removed.');
+
+        return self::SUCCESS;
+    }
+
+    private function confirmedRemoval(): bool
+    {
+        if ($this->option('force')) {
+            return true;
+        }
+
+        return confirm(
+            label: 'This removes the built-in SEO global, fieldsets, templates and trackers. Continue?',
+            default: false
+        );
+    }
+
+    /**
+     * Collect every field handle defined across the SEO fieldsets so the same
+     * keys can be pruned from existing entries.
+     *
+     * @return list<string>
+     */
+    private function seoFieldHandles(): array
+    {
+        return collect(self::SEO_FIELDSETS)
+            ->map(fn (string $fieldset): string => $this->fieldsetPath($fieldset))
+            ->filter(fn (string $path): bool => $this->files->exists($path))
+            ->flatMap(fn (string $path): array => Arr::get(YAML::file($path)->parse(), 'fields', []))
+            ->pluck('handle')
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  list<string>  $handles
+     */
+    private function stripSeoFieldsFromEntries(array $handles): void
+    {
+        if (empty($handles)) {
+            return;
+        }
+
+        $stripped = EntryFacade::all()
+            ->filter(fn (Entry $entry): bool => $this->stripHandlesFromEntry($entry, $handles))
+            ->each(fn (Entry $entry) => $entry->save())
+            ->count();
+
+        if ($stripped > 0) {
+            info("Stripped SEO fields from {$stripped} ".Str::plural('entry', $stripped).'.');
+        }
+    }
+
+    /**
+     * @param  list<string>  $handles
+     */
+    private function stripHandlesFromEntry(Entry $entry, array $handles): bool
+    {
+        $present = collect($handles)->filter(fn (string $handle): bool => $entry->has($handle));
+
+        $present->each(fn (string $handle) => $entry->remove($handle));
+
+        return $present->isNotEmpty();
+    }
+
+    private function deleteSeoFiles(): void
+    {
+        $this->deletePaths(
+            collect(self::SEO_FIELDSETS)
+                ->map(fn (string $fieldset): string => $this->fieldsetPath($fieldset))
+                ->push(
+                    $this->resourcePath('blueprints/globals/seo.yaml'),
+                    $this->contentPath('globals/seo.yaml'),
+                    $this->contentPath('globals/default/seo.yaml'),
+                    $this->contentPath('seo.yaml'),
+                    $this->resourcePath('views/partials/seo.antlers.html'),
+                    $this->resourcePath('views/partials/fallback-description.antlers.html'),
+                    $this->resourcePath('views/partials/cookie-dialog.antlers.html'),
+                    $this->resourcePath('js/components/cookieDialog.js'),
+                )
+        );
+    }
+
+    private function deletePaths(Collection $paths): void
+    {
+        $paths
+            ->filter(fn (string $path): bool => $this->files->exists($path))
+            ->each(fn (string $path) => $this->files->delete($path));
+    }
+
+    private function removeSeoTabFromBlueprints(): void
+    {
+        collect([
+            $this->resourcePath('blueprints/collections/pages/page.yaml'),
+            $this->resourcePath('blueprints/collections/posts/post.yaml'),
+        ])
+            ->filter(fn (string $path): bool => $this->files->exists($path))
+            ->each(function (string $path): void {
+                $data = YAML::file($path)->parse();
+                Arr::forget($data, 'tabs.seo');
+                $this->files->put($path, YAML::dump($data));
+            });
+    }
+
+    private function cleanUpTemplates(): void
+    {
+        $this->replaceInFile(
+            $this->resourcePath('views/layout.antlers.html'),
+            [
+                '<s:partial:partials.seo />' => '{{# Add your SEO addon meta tag here, e.g. {{ seo_pro:meta }} #}}',
+                "        {{ yield:seo_body }}\n" => '',
+            ]
+        );
+
+        $this->replaceInFile(
+            $this->resourcePath('views/partials/nav-bottom-footer.antlers.html'),
+            [
+                "        {{# Let's users reset their cookies consent when using the cookie banner. #}}\n        {{ yield:reset_cookie_consent }}\n" => '',
+            ]
+        );
+
+        $this->replaceInFile(
+            $this->resourcePath('views/partials/social-sharing.antlers.html'),
+            ['&via={{ seo:twitter_site }}' => ''],
+        );
+    }
+
+    private function removeCookieDialogFromVite(): void
+    {
+        $this->replaceInFile(
+            $this->basePath().'/vite.config.js',
+            ["          'resources/js/components/cookieDialog.js',\n" => ''],
+        );
+    }
+
+    /**
+     * @param  array<string, string>  $replacements
+     */
+    private function replaceInFile(string $path, array $replacements): void
+    {
+        if (! $this->files->exists($path)) {
+            warning("Skipped missing file: {$path}");
+
+            return;
+        }
+
+        $contents = Str::replace(
+            array_keys($replacements),
+            array_values($replacements),
+            $this->files->get($path)
+        );
+
+        $this->files->put($path, $contents);
+    }
+
+    private function clearStache(): void
+    {
+        Stache::clear();
+        info('Cleared the Stache.');
+    }
+
+    private function printNextSteps(): void
+    {
+        warning('The cookie-consent dialog and analytics trackers were removed; re-add them separately if needed.');
+        info('Next: install your SEO addon (e.g. `composer require statamic/seo-pro`) and add its meta tag in layout.antlers.html where the SEO partial used to be.');
+    }
+
+    private function fieldsetPath(string $handle): string
+    {
+        return config('statamic.bedrock.scaffold.fieldsets_path')."/{$handle}.yaml";
+    }
+
+    /**
+     * Root for the kit's file tree. Overridable via config so tests can point
+     * the command at an isolated scratch copy instead of the real repo files.
+     */
+    private function basePath(): string
+    {
+        return config('statamic.bedrock.seo_removal.base_path') ?? base_path();
+    }
+
+    private function resourcePath(string $relative): string
+    {
+        return $this->basePath()."/resources/{$relative}";
+    }
+
+    private function contentPath(string $relative): string
+    {
+        return $this->basePath()."/content/{$relative}";
+    }
+}

--- a/export/tests/Feature/Console/RemoveSeoCommandTest.php
+++ b/export/tests/Feature/Console/RemoveSeoCommandTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Laravel\Prompts\ConfirmPrompt;
+use Laravel\Prompts\Prompt;
+use Statamic\Facades\Entry;
+use Statamic\Facades\YAML;
+
+beforeAll(function () {
+    // Always auto-confirm destructive prompts in tests.
+    Prompt::fallbackWhen(true);
+    ConfirmPrompt::fallbackUsing(fn () => true);
+});
+
+beforeEach(function () {
+    setUpSeoRemovalScratch();
+
+    $this->base = bedrockSeoScratchBase();
+    $this->fieldsetsPath = config('statamic.bedrock.scaffold.fieldsets_path');
+
+    // Worker-unique handles so entry stripping only touches the seeded entry,
+    // never real demo content (keeps the suite parallel-safe).
+    $token = bedrockTestWorkerToken();
+    $this->seoTitleHandle = "seo_title_{$token}";
+    $this->ogImageHandle = "og_image_{$token}";
+
+    writeSeoFieldset($this->fieldsetsPath, 'seo_basic', [$this->seoTitleHandle]);
+    writeSeoFieldset($this->fieldsetsPath, 'seo_open_graph', [$this->ogImageHandle]);
+    foreach (['seo_advanced', 'seo_json-ld_schema', 'seo_sitemap'] as $fieldset) {
+        writeSeoFieldset($this->fieldsetsPath, $fieldset, []);
+    }
+
+    $entry = Entry::make();
+    $entry->collection('pages');
+    $entry->id($this->entryId = bedrockTestEntryId('test-page'));
+    $entry->slug($this->entryId);
+    $entry->data([
+        'title' => 'Test Page',
+        $this->seoTitleHandle => 'Custom title',
+        $this->ogImageHandle => 'og.jpg',
+    ]);
+    $entry->save();
+});
+
+afterEach(function () {
+    File::deleteDirectory(bedrockTestScratchPath());
+
+    $worker = bedrockTestWorkerToken();
+    foreach (glob(base_path("content/collections/pages/test-page-w{$worker}-*.md")) ?: [] as $file) {
+        @unlink($file);
+    }
+});
+
+function writeSeoFieldset(string $dir, string $handle, array $fieldHandles): void
+{
+    $fields = array_map(fn (string $field): array => [
+        'handle' => $field,
+        'field' => ['type' => 'text'],
+    ], $fieldHandles);
+
+    File::put("{$dir}/{$handle}.yaml", YAML::dump([
+        'title' => $handle,
+        'fields' => $fields,
+    ]));
+}
+
+test('bedrock:remove-seo deletes seo files and fieldsets', function () {
+    $this->artisan('bedrock:remove-seo', ['--force' => true])
+        ->assertExitCode(Command::SUCCESS);
+
+    $deleted = [
+        'resources/blueprints/globals/seo.yaml',
+        'resources/views/partials/seo.antlers.html',
+        'resources/views/partials/fallback-description.antlers.html',
+        'resources/views/partials/cookie-dialog.antlers.html',
+        'resources/js/components/cookieDialog.js',
+        'content/seo.yaml',
+        'content/globals/seo.yaml',
+        'content/globals/default/seo.yaml',
+    ];
+
+    foreach ($deleted as $relative) {
+        expect(is_file("{$this->base}/{$relative}"))->toBeFalse();
+    }
+
+    foreach (['seo_basic', 'seo_advanced', 'seo_open_graph', 'seo_json-ld_schema', 'seo_sitemap'] as $fieldset) {
+        expect(is_file("{$this->fieldsetsPath}/{$fieldset}.yaml"))->toBeFalse();
+    }
+});
+
+test('bedrock:remove-seo removes the seo tab from collection blueprints', function () {
+    $this->artisan('bedrock:remove-seo', ['--force' => true])
+        ->assertExitCode(Command::SUCCESS);
+
+    foreach (['pages/page', 'posts/post'] as $blueprint) {
+        $data = YAML::file("{$this->base}/resources/blueprints/collections/{$blueprint}.yaml")->parse();
+        expect($data['tabs'])->not->toHaveKey('seo');
+    }
+});
+
+test('bedrock:remove-seo cleans template and build references', function () {
+    $this->artisan('bedrock:remove-seo', ['--force' => true])
+        ->assertExitCode(Command::SUCCESS);
+
+    $layout = File::get("{$this->base}/resources/views/layout.antlers.html");
+    expect($layout)->not->toContain('partials.seo')
+        ->and($layout)->not->toContain('yield:seo_body');
+
+    $footer = File::get("{$this->base}/resources/views/partials/nav-bottom-footer.antlers.html");
+    expect($footer)->not->toContain('reset_cookie_consent');
+
+    $social = File::get("{$this->base}/resources/views/partials/social-sharing.antlers.html");
+    expect($social)->not->toContain('seo:twitter_site');
+
+    $vite = File::get("{$this->base}/vite.config.js");
+    expect($vite)->not->toContain('cookieDialog.js');
+});
+
+test('bedrock:remove-seo strips seo keys from existing entries', function () {
+    $this->artisan('bedrock:remove-seo', ['--force' => true])
+        ->assertExitCode(Command::SUCCESS);
+
+    $entry = Entry::find($this->entryId);
+
+    expect($entry)->not->toBeNull()
+        ->and($entry->has($this->seoTitleHandle))->toBeFalse()
+        ->and($entry->has($this->ogImageHandle))->toBeFalse()
+        ->and($entry->get('title'))->toBe('Test Page');
+});

--- a/export/tests/Pest.php
+++ b/export/tests/Pest.php
@@ -107,3 +107,58 @@ function bedrockTestEntryId(string $prefix): string
 {
     return $prefix.'-w'.bedrockTestWorkerToken().'-'.Str::random(6);
 }
+
+/**
+ * Worker-scoped scratch root the bedrock:remove-seo command is pointed at so it
+ * mutates an isolated copy of the kit files instead of the real repo.
+ */
+function bedrockSeoScratchBase(): string
+{
+    return bedrockTestScratchPath().'/seo-root';
+}
+
+/**
+ * Copy the files bedrock:remove-seo edits/deletes into the scratch root and
+ * rebind config so the command operates there. The SEO fieldsets are seeded
+ * separately by the test with worker-unique handles.
+ */
+function setUpSeoRemovalScratch(): void
+{
+    $base = bedrockSeoScratchBase();
+
+    $files = [
+        'resources/blueprints/globals/seo.yaml',
+        'resources/blueprints/collections/pages/page.yaml',
+        'resources/blueprints/collections/posts/post.yaml',
+        'resources/views/layout.antlers.html',
+        'resources/views/partials/seo.antlers.html',
+        'resources/views/partials/fallback-description.antlers.html',
+        'resources/views/partials/cookie-dialog.antlers.html',
+        'resources/views/partials/nav-bottom-footer.antlers.html',
+        'resources/views/partials/social-sharing.antlers.html',
+        'resources/js/components/cookieDialog.js',
+        'content/seo.yaml',
+        'content/globals/seo.yaml',
+        'content/globals/default/seo.yaml',
+        'vite.config.js',
+    ];
+
+    foreach ($files as $relative) {
+        $source = base_path($relative);
+
+        if (! is_file($source)) {
+            continue;
+        }
+
+        $destination = "{$base}/{$relative}";
+        File::ensureDirectoryExists(dirname($destination));
+        File::copy($source, $destination);
+    }
+
+    File::ensureDirectoryExists("{$base}/resources/fieldsets");
+
+    config([
+        'statamic.bedrock.seo_removal.base_path' => $base,
+        'statamic.bedrock.scaffold.fieldsets_path' => "{$base}/resources/fieldsets",
+    ]);
+}


### PR DESCRIPTION
## What's new
- `bedrock:remove-seo` artisan command that strips the built-in SEO implementation (global, fieldsets, blueprints, templates and trackers) so an SEO addon can be installed on a blank slate
- Feature test coverage for file/fieldset deletion, blueprint tab removal, template/build cleanup, and entry field stripping
- Worker-scoped Pest helpers (`bedrockSeoScratchBase`, `setUpSeoRemovalScratch`) so the command runs against an isolated scratch copy in parallel-safe tests
- Composer `post-update-cmd` scripts to publish Laravel assets and run `boost:update` after updates

## What's fixed
- Nothing