### PR TITLE
Install dev dependencies from the post-install hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In the age of LLM agents, the only way to prevent the slop, is to enforce strict
 
 - **100% type coverage.** Every parameter, property, and return value is explicitly typed. Enforced by `pest --type-coverage --min=100`.
 - **100% test coverage.** The test run fails below *and* above 100%, so coverage cannot silently drift.
-- **Zero tolerance for code smell.** Rector and PHPStan at maximum strictness catch issues before they become bugs.
+- **Zero tolerance for code smell.** PHPStan at level 9 catch issues before they become bugs.
 - **Tests fails on anything suspicious.** Deprecations, notices, warnings, risky tests, unexpected output, and tests that assert nothing all fail the suite.
 - **Immutable-first architecture.** Data structures favor immutability to prevent unexpected mutations.
 - **Automated code quality.** `composer lint` fixes what it can. `composer test` refuses to pass anything else. Nobody has to police style in code review.

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -2,14 +2,47 @@
 
 declare(strict_types=1);
 
+use Illuminate\Console\Command;
+use Statamic\Console\NullConsole;
+use Statamic\Console\Processes\Composer;
+
 use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
 
 final class StarterKitPostInstall
 {
-    public function handle($console): void
+    /**
+     * Statamic installs `dependencies_dev` with a partial `composer require` that cannot
+     * pass `--with-all-dependencies`, which Pest 5 and PHPUnit 13 need, so this hook
+     * installs them instead. `export-starter-kit.sh` fails when a version here drifts
+     * from require-dev in composer.json.
+     *
+     * @var list<string>
+     */
+    public const DEV_DEPENDENCIES = [
+        'cboxdk/statamic-mcp:^2.5',
+        'driftingly/rector-laravel:^2.5',
+        'larastan/larastan:^3.9.6',
+        'laravel/boost:^2.4.8',
+        'laravel/pao:^1.1',
+        'pestphp/pest:^5.0.4',
+        'pestphp/pest-plugin-browser:^5.0',
+        'pestphp/pest-plugin-laravel:^5.0.1',
+        'pestphp/pest-plugin-phpstan:^5.0.2',
+        'pestphp/pest-plugin-rector:^5.0.3',
+        'pestphp/pest-plugin-type-coverage:^5.0.2',
+        'phpstan/phpstan:^2.2.8',
+        'phpunit/phpunit:^13.2.6',
+        'rector/rector:^2.6.1',
+        'roave/security-advisories:dev-latest',
+    ];
+
+    public function handle(Command|NullConsole $console): void
     {
         info('Thanks for installing Bedrock starter kit!');
+
+        $this->installDevDependencies($console);
 
         $this->mergeComposerScripts();
 
@@ -17,6 +50,38 @@ final class StarterKitPostInstall
         exec('composer run lint');
 
         $this->starRepo();
+    }
+
+    private function installDevDependencies(Command|NullConsole $console): void
+    {
+        info('Installing dev dependencies...');
+
+        $arguments = array_merge(
+            ['require', '--dev', '--with-all-dependencies', '--no-interaction'],
+            self::DEV_DEPENDENCIES,
+        );
+
+        try {
+            Composer::create(getcwd())
+                ->withoutQueue()
+                ->throwOnFailure()
+                ->runAndOperateOnOutput($arguments, function (string $output) use ($console): string {
+                    $line = mb_trim($output);
+
+                    if ($line !== '') {
+                        $console->line($line);
+                    }
+
+                    return $output;
+                });
+        } catch (Throwable) {
+            error('Failed to install dev dependencies. Please run this command manually:');
+            error('composer require --dev -W '.implode(' ', self::DEV_DEPENDENCIES));
+
+            return;
+        }
+
+        info('Installed dev dependencies.');
     }
 
     private function mergeComposerScripts(): void

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -40,19 +40,3 @@ export_paths:
   - vite.config.js
 dependencies:
   nunomaduro/essentials: ^1.2
-dependencies_dev:
-  cboxdk/statamic-mcp: ^2.5
-  driftingly/rector-laravel: ^2.5
-  larastan/larastan: ^3.9.6
-  laravel/boost: ^2.4.8
-  laravel/pao: ^1.1
-  pestphp/pest: ^5.0.4
-  pestphp/pest-plugin-browser: ^5.0
-  pestphp/pest-plugin-laravel: ^5.0.1
-  pestphp/pest-plugin-phpstan: ^5.0.2
-  pestphp/pest-plugin-rector: ^5.0.3
-  pestphp/pest-plugin-type-coverage: ^5.0.2
-  phpstan/phpstan: ^2.2.8
-  phpunit/phpunit: ^13.2.6
-  rector/rector: ^2.6.1
-  roave/security-advisories: dev-latest


### PR DESCRIPTION
## What's new
- `StarterKitPostInstall` now installs all dev dependencies with `composer require --dev --with-all-dependencies`.
- Dev dependency versions live in a single `DEV_DEPENDENCIES` constant.
- The hook prints composer output live and shows a manual fallback command if the install fails.

## What's fixed
- Pest 5 and PHPUnit 13 install correctly. Statamic's `dependencies_dev` handling cannot pass `--with-all-dependencies`, so `dependencies_dev` is removed from `starter-kit.yaml`.
- README no longer claims Rector runs at maximum strictness.
