### PR TITLE
Install node dependencies during post-install and add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In the age of LLM agents, the only way to prevent the slop, is to enforce strict
 
 - **100% type coverage.** Every parameter, property, and return value is explicitly typed. Enforced by `pest --type-coverage --min=100`.
 - **100% test coverage.** The test run fails below *and* above 100%, so coverage cannot silently drift.
-- **Zero tolerance for code smell.** PHPStan at level 9 catch issues before they become bugs.
+- **Zero tolerance for code smell.** PHPStan at level 9 catches issues before they become bugs.
 - **Tests fails on anything suspicious.** Deprecations, notices, warnings, risky tests, unexpected output, and tests that assert nothing all fail the suite.
 - **Immutable-first architecture.** Data structures favor immutability to prevent unexpected mutations.
 - **Automated code quality.** `composer lint` fixes what it can. `composer test` refuses to pass anything else. Nobody has to police style in code review.

--- a/StarterKitPostInstall.php
+++ b/StarterKitPostInstall.php
@@ -15,8 +15,7 @@ final class StarterKitPostInstall
     /**
      * Statamic installs `dependencies_dev` with a partial `composer require` that cannot
      * pass `--with-all-dependencies`, which Pest 5 and PHPUnit 13 need, so this hook
-     * installs them instead. `export-starter-kit.sh` fails when a version here drifts
-     * from require-dev in composer.json.
+     * installs them instead.
      *
      * @var list<string>
      */
@@ -46,8 +45,9 @@ final class StarterKitPostInstall
 
         $this->mergeComposerScripts();
 
-        // run initial formatting over default Statamic/Laravel
-        exec('composer run lint');
+        if ($this->installNodeDependencies()) {
+            $this->formatDefaultFiles();
+        }
 
         $this->starRepo();
     }
@@ -84,6 +84,34 @@ final class StarterKitPostInstall
         info('Installed dev dependencies.');
     }
 
+    private function installNodeDependencies(): bool
+    {
+        info('Installing node dependencies...');
+
+        passthru('bun install', $exitCode);
+
+        if ($exitCode !== 0) {
+            error('Failed to install node dependencies. Please run `bun install` manually, then `composer run lint`.');
+
+            return false;
+        }
+
+        info('Installed node dependencies.');
+
+        return true;
+    }
+
+    private function formatDefaultFiles(): void
+    {
+        info('Formatting default Statamic/Laravel files...');
+
+        passthru('composer run lint', $exitCode);
+
+        if ($exitCode !== 0) {
+            error('Failed to format the default files. Please run `composer run lint` manually.');
+        }
+    }
+
     private function mergeComposerScripts(): void
     {
         $path = getcwd().'/composer.json';
@@ -106,6 +134,14 @@ final class StarterKitPostInstall
     private function customScripts(): array
     {
         return [
+            'setup' => [
+                'composer install',
+                "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
+                '@php artisan key:generate',
+                '@php artisan migrate --force',
+                'bun install',
+                'bun run build',
+            ],
             'dev' => [
                 'Composer\\Config::disableProcessTimeout',
                 'bunx concurrently -c "#c4b5fd,#fb7185,#fdba74" "php artisan queue:listen --tries=1" "php artisan pail --timeout=0" "bun run dev" --names=queue,logs,vite',


### PR DESCRIPTION
## What's new
- Post-install now runs `bun install` before formatting, so `composer run lint` has the node tooling it needs.
- New `composer setup` script: install, env file, key generate, migrate, `bun install`, `bun run build`.

## What's fixed
- Post-install reports a clear error and skips formatting when `bun install` or `composer run lint` fails, instead of failing silently.
- Corrected a grammar mistake in the README PHPStan line.