### PR TITLE
Add user model, factory, filesystems and MCP config to export paths

### DIFF
--- a/export/app/Models/User.php
+++ b/export/app/Models/User.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Database\Factories\UserFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+#[Fillable([
+    'name',
+    'email',
+    'password',
+])]
+#[Hidden([
+    'password',
+    'remember_token',
+])]
+final class User extends Authenticatable
+{
+    /** @use HasFactory<UserFactory> */
+    use HasFactory;
+
+    use Notifiable;
+
+    /**
+     * @return array<string, string>
+     */
+    public function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/export/config/filesystems.php
+++ b/export/config/filesystems.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Filesystem Disk
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default filesystem disk that should be used
+    | by the framework. The "local" disk, as well as a variety of cloud
+    | based disks are available to your application for file storage.
+    |
+    */
+
+    'default' => env('FILESYSTEM_DISK', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filesystem Disks
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure as many filesystem disks as necessary, and you
+    | may even configure multiple disks for the same driver. Examples for
+    | most supported storage drivers are configured here for reference.
+    |
+    | Supported drivers: "local", "ftp", "sftp", "s3"
+    |
+    */
+
+    'disks' => [
+
+        'local' => [
+            'driver' => 'local',
+            'root' => storage_path('app/private'),
+            'serve' => true,
+            'throw' => false,
+            'report' => false,
+        ],
+
+        'public' => [
+            'driver' => 'local',
+            'root' => storage_path('app/public'),
+            'url' => mb_rtrim((string) env('APP_URL', 'http://localhost'), '/').'/storage',
+            'visibility' => 'public',
+            'throw' => false,
+            'report' => false,
+        ],
+
+        's3' => [
+            'driver' => 's3',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION'),
+            'bucket' => env('AWS_BUCKET'),
+            'url' => env('AWS_URL'),
+            'endpoint' => env('AWS_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw' => false,
+            'report' => false,
+            // 'visibility' => 'public', // https://statamic.dev/assets#container-visibility
+        ],
+
+        'assets' => [
+            'driver' => 'local',
+            'root' => public_path('assets'),
+            'url' => '/assets',
+            'visibility' => 'public',
+            'throw' => false,
+            'report' => false,
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Symbolic Links
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the symbolic links that will be created when the
+    | `storage:link` Artisan command is executed. The array keys should be
+    | the locations of the links and the values should be their targets.
+    |
+    */
+
+    'links' => [
+        public_path('storage') => storage_path('app/public'),
+    ],
+
+];

--- a/export/config/statamic/mcp.php
+++ b/export/config/statamic/mcp.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+use Cboxdk\StatamicMcp\OAuth\Drivers\BuiltInOAuthDriver;
+use Cboxdk\StatamicMcp\Storage\Audit\FileAuditStore;
+use Cboxdk\StatamicMcp\Storage\Tokens\FileTokenStore;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Statamic MCP Server v2.0 Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure the Statamic MCP server for CLI and web access,
+    | authentication, dashboard, and per-domain tool settings.
+    |
+    */
+
+    /*
+    |--------------------------------------------------------------------------
+    | Web MCP Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure web-accessible MCP endpoints with authentication and routing.
+    |
+    */
+    'web' => [
+        'enabled' => env('STATAMIC_MCP_WEB_ENABLED', true),
+        'path' => env('STATAMIC_MCP_WEB_PATH', '/mcp/statamic'),
+
+        // Reject plain HTTP requests to the MCP endpoint (skipped in local/testing)
+        'require_https' => env('STATAMIC_MCP_WEB_REQUIRE_HTTPS', true),
+
+        // Allowed CORS origins for browser-based MCP clients.
+        // Use ['*'] to allow all origins, or specify domains: ['https://example.com']
+        // Leave empty to disable CORS headers (desktop MCP clients don't need them).
+        'allowed_origins' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Storage Drivers
+    |--------------------------------------------------------------------------
+    |
+    | Configure which storage drivers to use for tokens and audit logs.
+    | Swap to database drivers for multi-server / HA deployments.
+    |
+    | Supported: FileTokenStore (default), DatabaseTokenStore
+    |            FileAuditStore (default), DatabaseAuditStore
+    |
+    */
+    'stores' => [
+        'tokens' => FileTokenStore::class,
+        'audit' => FileAuditStore::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Storage Paths
+    |--------------------------------------------------------------------------
+    |
+    | File paths used by the file-based storage drivers.
+    |
+    */
+    'storage' => [
+        'tokens_path' => storage_path('statamic-mcp/tokens'),
+        'audit_path' => storage_path('statamic-mcp/audit.log'),
+        'oauth_clients_path' => storage_path('statamic-mcp/oauth/clients'),
+        'oauth_codes_path' => storage_path('statamic-mcp/oauth/codes'),
+        'oauth_refresh_path' => storage_path('statamic-mcp/oauth/refresh'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Dashboard Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure the Control Panel dashboard for managing MCP tokens,
+    | monitoring usage, and generating client configurations.
+    |
+    */
+    'dashboard' => [
+        'enabled' => env('STATAMIC_MCP_DASHBOARD_ENABLED', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Security Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure security settings for MCP server access and permissions.
+    |
+    */
+    'security' => [
+        // Force web authentication mode even for CLI context
+        'force_web_mode' => env('STATAMIC_MCP_FORCE_WEB_MODE', false),
+
+        // Audit logging for all MCP operations
+        'audit_logging' => env('STATAMIC_MCP_AUDIT_LOGGING', true),
+
+        // Maximum upload size in bytes (default: 10MB)
+        'max_upload_size' => env('STATAMIC_MCP_MAX_UPLOAD_SIZE', 10 * 1024 * 1024),
+
+        // Include version information in API responses (enable for debugging, disable in production)
+        'expose_versions' => env('STATAMIC_MCP_EXPOSE_VERSIONS', false),
+
+        // Maximum token lifetime in days (null = unlimited)
+        'max_token_lifetime_days' => env('STATAMIC_MCP_MAX_TOKEN_LIFETIME', 365),
+
+        'tool_timeout_seconds' => env('STATAMIC_MCP_TOOL_TIMEOUT', 30),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Confirmation Tokens
+    |--------------------------------------------------------------------------
+    |
+    | Require a two-step confirmation flow for destructive operations.
+    | Uses stateless HMAC-SHA256 tokens bound to the exact operation.
+    |
+    | When enabled is null (default), confirmation is auto-detected:
+    | enabled in production, disabled in local/development/testing/staging.
+    | Set to true/false to override.
+    |
+    */
+    'confirmation' => [
+        'enabled' => env('STATAMIC_MCP_CONFIRMATION_ENABLED'),
+        'ttl' => (int) env('STATAMIC_MCP_CONFIRMATION_TTL', 300),
+
+        /*
+        | Per-domain list of actions that require the confirmation-token flow.
+        | Domains not listed fall back to 'default'. An empty array disables
+        | the gate for that domain. The '*' wildcard gates every action.
+        |
+        | Defaults preserve historical behaviour: 'delete' everywhere plus
+        | create/update on blueprints, and destructive revision actions on
+        | entries. Operators can widen the gate per domain — e.g. require
+        | confirmation on entries.update — without forking the package.
+        */
+        'actions' => [
+            'default' => ['delete'],
+            'blueprints' => ['create', 'update', 'delete'],
+            'entries' => ['delete', 'restore_revision', 'publish_working_copy'],
+            // 'entries' => ['create', 'update', 'delete', 'publish', 'unpublish', 'restore_revision', 'publish_working_copy'],
+            // 'globals' => ['update'],
+            // 'terms'   => ['create', 'update', 'delete'],
+            // 'assets'  => ['upload', 'update', 'delete', 'move', 'copy'],
+            // 'users'   => ['create', 'update', 'delete', 'assign-role'],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate Limiting
+    |--------------------------------------------------------------------------
+    |
+    | Global rate limiting for MCP tool calls. Applied per-token for web
+    | requests and skipped for CLI context.
+    |
+    */
+    'rate_limit' => [
+        'max_attempts' => env('STATAMIC_MCP_RATE_LIMIT_MAX', 60),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | OAuth Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure the OAuth 2.1 authorization server for MCP client registration
+    | and token exchange using PKCE (RFC 7636).
+    |
+    */
+    'oauth' => [
+        'enabled' => env('STATAMIC_MCP_OAUTH_ENABLED', true),
+        'driver' => env('STATAMIC_MCP_OAUTH_DRIVER', BuiltInOAuthDriver::class),
+        'code_ttl' => (int) env('STATAMIC_MCP_OAUTH_CODE_TTL', 600),
+        'client_ttl' => (int) env('STATAMIC_MCP_OAUTH_CLIENT_TTL', 2592000),
+        'token_ttl' => (int) env('STATAMIC_MCP_OAUTH_TOKEN_TTL', 604800), // 7 days
+        'refresh_token_ttl' => (int) env('STATAMIC_MCP_OAUTH_REFRESH_TOKEN_TTL', 2592000), // 30 days
+        'default_scopes' => array_filter(explode(',', (string) env('STATAMIC_MCP_OAUTH_DEFAULT_SCOPES', 'content:read,blueprints:read,structures:read,entries:read,terms:read,globals:read,assets:read,system:read,content-facade:read'))),
+        'max_clients' => (int) env('STATAMIC_MCP_OAUTH_MAX_CLIENTS', 50),
+        'max_clients_per_ip' => (int) env('STATAMIC_MCP_OAUTH_MAX_CLIENTS_PER_IP', 5),
+
+        // Client ID Metadata Document (CIMD) support
+        'cimd_enabled' => env('STATAMIC_MCP_OAUTH_CIMD_ENABLED', true),
+        'cimd_fetch_timeout' => (int) env('STATAMIC_MCP_OAUTH_CIMD_FETCH_TIMEOUT', 5),
+        'cimd_max_response_size' => (int) env('STATAMIC_MCP_OAUTH_CIMD_MAX_RESPONSE_SIZE', 5120),
+        'cimd_cache_ttl' => (int) env('STATAMIC_MCP_OAUTH_CIMD_CACHE_TTL', 3600),
+        'cimd_block_private_ips' => env('STATAMIC_MCP_OAUTH_CIMD_BLOCK_PRIVATE_IPS', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tool Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Per-domain tool settings. Each tool can be toggled on/off via env vars.
+    | Set STATAMIC_MCP_TOOL_{NAME}_ENABLED=false to disable a specific tool.
+    |
+    */
+    'tools' => [
+        'blueprints' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_BLUEPRINTS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
+        ],
+        'entries' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_ENTRIES_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
+        ],
+        'terms' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_TERMS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
+        ],
+        'globals' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_GLOBALS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
+        ],
+        'structures' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_STRUCTURES_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
+        ],
+        'assets' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_ASSETS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
+        ],
+        'users' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_USERS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
+        ],
+        'system' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_SYSTEM_ENABLED', true),
+        ],
+        'content-facade' => [
+            'enabled' => env('STATAMIC_MCP_TOOL_CONTENT_FACADE_ENABLED', true),
+        ],
+    ],
+
+];

--- a/export/database/factories/UserFactory.php
+++ b/export/database/factories/UserFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<User>
+ */
+final class UserFactory extends Factory
+{
+    private static string $password;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => self::$password ??= Hash::make('password'),
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+    public function unverified(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'email_verified_at' => null,
+        ]);
+    }
+}

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -7,13 +7,17 @@ export_paths:
   - app/Enums
   - app/Fieldtypes
   - app/Http
+  - app/Models/User.php
   - app/Providers/AppServiceProvider.php
   - app/Support
   - app/Tags
+  - config/filesystems.php
   - config/essentials.php
   - config/statamic/bedrock.php
+  - config/statamic/mcp.php
   - config/statamic/git.php
   - config/statamic/search.php
+  - database/factories/UserFactory.php
   - content
   - public/assets
   - public/favicon


### PR DESCRIPTION
## What's new
- Export `app/Models/User.php` and `database/factories/UserFactory.php` with the starter kit
- Export `config/filesystems.php`
- Export `config/statamic/mcp.php` for the Statamic MCP server

## What's fixed
- Nothing in this release